### PR TITLE
Use first cmdline argument as a filename to open

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -29,7 +29,7 @@ class MainWindow(QMainWindow,MainMixin):
     name = 'CQ GUI'
     org = 'CadQuery'
     
-    def __init__(self,parent=None):
+    def __init__(self,parent=None,fname=''):
         
         super(MainWindow,self).__init__(parent)
         MainMixin.__init__(self)
@@ -51,7 +51,10 @@ class MainWindow(QMainWindow,MainMixin):
         
         self.prepare_console()
         
-        self.fill_dummy()
+        if fname:
+            self.components['editor'].openFile(fname)
+        else:
+            self.fill_dummy()
         
         self.setup_logging()
         
@@ -302,9 +305,17 @@ def main():
     
     app = QApplication(sys.argv,
                        applicationName='CadQuery GUI (PyQT)')
-    win = MainWindow()
+
+    # If an argument is provided, assume it's a filename
+    # $ qt-editor [filename.py]
+    fname = ''
+    if len(app.arguments()) == 2:
+        fname = app.arguments()[1]
+
+    win = MainWindow(fname=fname)
     
     win.show()
+
     sys.exit(app.exec_())
 
 

--- a/src/widgets/editor.py
+++ b/src/widgets/editor.py
@@ -44,7 +44,7 @@ class Editor(CodeEditor,ComponentMixin):
                                   self,triggered=self.new),
                           QAction(icon('open'),
                                   'Open',
-                                  self,triggered=self.open),
+                                  self,triggered=self.openDialog),
                           QAction(icon('save'),
                                   'Save',
                                   self,triggered=self.save),
@@ -81,12 +81,16 @@ class Editor(CodeEditor,ComponentMixin):
         self._filename = ''
         self.set_text('')
 
-    def open(self):
-        
-        fname,_ = QFileDialog.getOpenFileName(self,filter=self.EXTENSIONS)
+    def openFile(self, fname):
+
         if fname is not '':
             self.set_text_from_file(fname)
             self._filename = fname
+
+    def openDialog(self):
+
+        fname,_ = QFileDialog.getOpenFileName(self,filter=self.EXTENSIONS)
+        self.openFile(fname)
     
     def save(self):
         


### PR DESCRIPTION
This lets you do `$ cq-editor mymodel.py` to open it immediately, rather than launching and opening through the file dialog.

Is there a preferred way to do argument parsing/handling? I typically use `argparse` for this sort of thing, but `QApplication` also does its own handling.