### PR TITLE
Watch for file changes and automatically reload and rerender

### DIFF
--- a/src/icons.py
+++ b/src/icons.py
@@ -16,6 +16,8 @@ from . import icons_res
 _icons_specs = {
     'new'  : (('fa.file-o',),{}),
     'open' : (('fa.folder-open-o',),{}),
+    # borrowed from spider-ide
+    'autoreload': [('fa.repeat', 'fa.clock-o'), {'options': [{'scale_factor': 0.75, 'offset': (-0.1, -0.1)}, {'scale_factor': 0.5, 'offset': (0.25, 0.25)}]}],
     'save' : (('fa.save',),{}),
     'save_as': (('fa.save','fa.pencil'),
                {'options':[{'scale_factor': 1,},

--- a/src/main.py
+++ b/src/main.py
@@ -234,6 +234,10 @@ class MainWindow(QMainWindow,MainMixin):
             .connect(self.components['object_tree'].addObjects)
         self.components['debugger'].sigTraceback\
             .connect(self.components['traceback_viewer'].addTraceback)
+
+        # trigger re-render when file is modified externally or saved
+        self.components['editor'].triggerRerender \
+            .connect(self.components['debugger'].render)
             
     def prepare_console(self):
         


### PR DESCRIPTION
Here's a first attempt at adding an autoreload option as described in #11. When enabled, it watches the currently-open file with QFileSystemWatcher and refreshes and rerenders whenever the file is changed externally or saved within cq-editor.

Let me know what suggestions you have for implementation, testing, UI, etc.