### PR TITLE
ObjectTree: preserve properties

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -669,6 +669,29 @@ def test_auto_fit_view(main_clean):
     assert( concat(eye3,proj3,scale3) != \
             approx_view_properties(eye4,proj4,scale4) )
 
+def test_preserve_properties(main):
+    qtbot, win = main
+
+    debugger = win.components['debugger']
+    debugger._actions['Run'][0].triggered.emit()
+
+    object_tree = win.components['object_tree']
+    object_tree.preferences['Preserve properties on reload'] = True
+
+    assert(object_tree.CQ.childCount() == 1)
+    props = object_tree.CQ.child(0).properties
+    props['Visible'] = False
+    props['Color'] = '#caffee'
+    props['Alpha'] = 0.5
+
+    debugger._actions['Run'][0].triggered.emit()
+
+    assert(object_tree.CQ.childCount() == 1)
+    props = object_tree.CQ.child(0).properties
+    assert(props['Visible'] == False)
+    assert(props['Color'].name() == '#caffee')
+    assert(props['Alpha'] == 0.5)
+
 def test_selection(main_multi,mocker):
 
     qtbot, win = main_multi


### PR DESCRIPTION
If I have multiple models, I sometimes only want to look at one model, and maybe make the others transparent and/or have a different color.  Particularly transparency is really useful to see inside a model.  However all of these settings are lost every time the file is rendered.

This PR adds an option to copy the properties to the newly rendered models (taking the properties from the model with the same name).  I'm not sure if it's the best solution (or if this can already be done), but it works for me.