### PR TITLE
Added options input for show_object

### DIFF
--- a/src/widgets/debugger.py
+++ b/src/widgets/debugger.py
@@ -199,7 +199,7 @@ class Debugger(QObject,ComponentMixin):
 
         cq_objects = {}
 
-        def _show_object(obj,name=None):
+        def _show_object(obj,name=None, options={}):
 
             if name:
                 cq_objects.update({name : obj})


### PR DESCRIPTION
The purpose of this PR is to make `show_object` conforming the CQGI behavior, i.e. add an `options={}` keyword argument. For now it will have no actual effect, but will allow to render old CQ1 scripts that relied on this functionality.