### PR TITLE
File open dialog starts in current script's directory

### DIFF
--- a/cq_editor/utils.py
+++ b/cq_editor/utils.py
@@ -98,9 +98,9 @@ def get_save_filename(suffix):
     
     return rv
 
-def get_open_filename(suffix):
+def get_open_filename(suffix, curr_dir):
     
-    rv,_ = QFileDialog.getOpenFileName(filter='*.{}'.format(suffix))    
+    rv,_ = QFileDialog.getOpenFileName(directory=curr_dir, filter='*.{}'.format(suffix))
     if rv is not '' and not rv.endswith(suffix): rv += '.'+suffix
     
     return rv

--- a/cq_editor/widgets/editor.py
+++ b/cq_editor/widgets/editor.py
@@ -2,6 +2,7 @@ from spyder.widgets.sourcecode.codeeditor import  CodeEditor
 from PyQt5.QtCore import pyqtSignal, QFileSystemWatcher, QTimer
 from PyQt5.QtWidgets import QAction, QFileDialog
 from PyQt5.QtGui import QFontDatabase
+from path import Path
 
 import sys
 
@@ -119,7 +120,8 @@ class Editor(CodeEditor,ComponentMixin):
 
     def open(self):
 
-        fname = get_open_filename(self.EXTENSIONS)
+        curr_dir = Path(self.filename).abspath().dirname()
+        fname = get_open_filename(self.EXTENSIONS, curr_dir)
         if fname is not '':
             self.load_from_file(fname)
 


### PR DESCRIPTION
When CQ-editor starts, it auto loads the previous script you were working on (great feature BTW). When opening the open file dialog for the first time, it will not point at that script's directory. This feels unintuitive and I also had to click a bunch of folders every time I started CQ-editor.

I've taken the directory from `Editor.filename` and supplied it to the file open dialog as the starting directory. 

Tested if `Editor.filename` is `''` and `pathlib.Path('').parent` produces `'.'`, which opens up the current working directory, so that case is handled properly. 