### PR TITLE
show_object method now uses options argument to pass alpha and color on to addObject

### DIFF
--- a/cq_editor/widgets/debugger.py
+++ b/cq_editor/widgets/debugger.py
@@ -201,6 +201,12 @@ class Debugger(QObject,ComponentMixin):
 
         def _show_object(obj,name=None, options={}):
 
+            obj = dict(obj=obj)
+            
+            if len(options) > 0:
+                for k,v in options.items():
+                    obj[k] = v
+
             if name:
                 cq_objects.update({name : obj})
             else:

--- a/cq_editor/widgets/object_tree.py
+++ b/cq_editor/widgets/object_tree.py
@@ -250,7 +250,7 @@ class ObjectTree(QWidget,ComponentMixin):
         ais_list = []
 
         #convert cq.Shape objects to cq.Workplane
-        tmp = ((k,v) if isinstance(v,cq.Workplane) else (k,to_workplane(v)) \
+        tmp = ((k,v['obj']) if isinstance(v['obj'],cq.Workplane) else (k,to_workplane(v['obj'])) \
                for k,v in objects.items())
         #remove Vector objects
         objects_f = \
@@ -267,6 +267,10 @@ class ObjectTree(QWidget,ComponentMixin):
             if preserve_props and name in old_params:
                 for p in old_params[name]:
                     child.properties[p.name()] = p.value()
+            if 'color' in objects[name]:
+                child.properties['Color'] = objects[name]['color']
+            if 'alpha' in objects[name]:
+                child.properties['Alpha'] = objects[name]['alpha']
             if child.properties['Visible']:
                 ais_list.append(ais)
             root.addChild(child)


### PR DESCRIPTION
This relates to https://github.com/CadQuery/CQ-editor/issues/53

Note that color is not transformed or checked in any way, it is just passed on to the object_tree properties.

This does change the structure of the data sent to addObject.  Instead of {name: Workplane_object} it's now {name: {obj: workplane_object, alpha: NUM, color: STRING}}.  This change is hidden externally via _show_object, but not hidden to direct calling in the console.

That could be addressed via checking and casting in addObject, or the creation of a simple _show_object method inside of the prepare_console method.  Opinions?