### PR TITLE
fix path import issue

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,4 +1,4 @@
-from path import Path
+from pathlib import Path
 import os, sys
 
 from multiprocessing import Process


### PR DESCRIPTION
This `from path import Path` line triggers the error `ImportError: No module named path` and the test fails.

It's fixed when using `pathlib` instead.