### PR TITLE
Fix iso view to match startup view

### DIFF
--- a/cq_editor/widgets/viewer.py
+++ b/cq_editor/widgets/viewer.py
@@ -195,7 +195,7 @@ class OCCViewer(QWidget,ComponentMixin):
     def iso_view(self):
 
         v = self._get_view()
-        v.SetProj(1,1,1)
+        v.SetProj(1,-1,1)
         v.SetTwist(0)
 
     def bottom_view(self):


### PR DESCRIPTION
Match iso view button with startup view and iso view of FreeCAD.

Startup: 
![image](https://user-images.githubusercontent.com/37172067/81586987-af252700-93b6-11ea-9696-2e9a16888afa.png)

Current Iso-View:
![image](https://user-images.githubusercontent.com/37172067/81587159-ec89b480-93b6-11ea-9945-9a79d86681d3.png)
