### PR TITLE
TopoDS_Shape support

### DIFF
--- a/cq_editor/cq_utils.py
+++ b/cq_editor/cq_utils.py
@@ -4,6 +4,7 @@ from typing import List, Union, Tuple
 from imp import reload
 from types import SimpleNamespace
 
+from OCP.TopoDS import TopoDS_Shape
 from OCP.AIS import AIS_ColoredShape
 from OCP.Quantity import \
     Quantity_TOC_RGB as TOC_RGB, Quantity_Color
@@ -36,6 +37,8 @@ def make_AIS(obj : Union[cq.Workplane, cq.Shape], options={}):
     
     if isinstance(obj, cq.Shape):
         obj = to_workplane(obj)
+    elif isinstance(obj, TopoDS_Shape):
+        obj = to_workplane(cq.Shape.cast(obj))
 
     shape = to_compound(obj)
     ais = AIS_ColoredShape(shape.wrapped)

--- a/cq_editor/widgets/cq_object_inspector.py
+++ b/cq_editor/widgets/cq_object_inspector.py
@@ -115,8 +115,9 @@ class CQObjectInspector(QTreeWidget,ComponentMixin):
     def setObject(self,cq_obj):
         
         self.root.takeChildren()
-
-        while cq_obj.parent:
+        
+        # iterate through parent objects if they exist
+        while getattr(cq_obj, 'parent', None):
             current_frame = CQStackItem(str(cq_obj.plane.origin),workplane=cq_obj)
             self.root.addChild(current_frame)
             

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1060,3 +1060,36 @@ def test_confirm_new(monkeypatch,editor):
     editor.new()
     assert(editor.modified == False)
     assert(editor.get_text_with_eol() == '')
+    
+code_show_topods = \
+'''
+import cadquery as cq
+result = cq.Workplane("XY" ).box(1, 1, 1)
+
+show_object(result.val().wrapped)
+'''
+
+def test_render_topods(main):
+
+    qtbot, win = main
+
+    obj_tree_comp = win.components['object_tree']
+    editor = win.components['editor']
+    debugger = win.components['debugger']
+    console = win.components['console']
+
+    # check that object was rendered
+    assert(obj_tree_comp.CQ.childCount() == 1)
+
+    # check that object was removed
+    obj_tree_comp._toolbar_actions[0].triggered.emit()
+    assert(obj_tree_comp.CQ.childCount() == 0)
+
+    # check that object was rendered usin explicit show_object call
+    editor.set_text(code_show_topods)
+    debugger._actions['Run'][0].triggered.emit()
+    assert(obj_tree_comp.CQ.childCount() == 1)
+    
+    # test rendering topods object via console
+    console.execute('show(result.val().wrapped)')
+    assert(obj_tree_comp.CQ.childCount() == 2)


### PR DESCRIPTION
This PR will enable showing `TopoDS_Shape` objects. It is very handy for developing CQ and low-level modeling.