### PR TITLE
Fix issue 197

### DIFF
--- a/cq_editor/widgets/viewer.py
+++ b/cq_editor/widgets/viewer.py
@@ -294,7 +294,7 @@ class OCCViewer(QWidget,ComponentMixin):
     def save_screenshot(self):
 
         fname = get_save_filename(self.IMAGE_EXTENSIONS)
-        if fname is not '':
+        if fname != '':
              self._get_view().Dump(fname)
 
     def _display_ais(self,ais):


### PR DESCRIPTION
A warning is issued when using "is not" with some literals, this changes
the code to use "!=".

Fixes #197