### PR TITLE
Update Pyinstaller spec

### DIFF
--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -20,9 +20,9 @@ elif sys.platform == 'win32':
 
 a = Analysis(['run.py'],
              pathex=['.'],
-             binaries=[],
+             binaries=[ocp_path],
              datas=[(spyder_data, 'spyder'),
-                    (occt_dir, 'ocp_path')] +
+                    (occt_dir, 'opencascade')] +
                     [(p, 'parso/python') for p in parso_grammar],
              hiddenimports=['ipykernel.datapub'],
              hookspath=[],

--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -12,7 +12,7 @@ if sys.platform == 'linux':
     occt_dir = os.path.join(Path(sys.prefix), 'share', 'opencascade')
     ocp_path = (os.path.join(HOMEPATH, 'OCP.cpython-38-x86_64-linux-gnu.so'), '.')
 elif sys.platform == 'darwin':
-    occt_dir = os.path.join(Path(sys.prefix), 'Library', 'share', 'opencascade')
+    occt_dir = os.path.join(Path(sys.prefix), 'share', 'opencascade')
     ocp_path = (os.path.join(HOMEPATH, 'OCP.cpython-38-darwin.so'), '.')
 elif sys.platform == 'win32':
     occt_dir = os.path.join(Path(sys.prefix), 'Library', 'share', 'opencascade')

--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -9,15 +9,20 @@ spyder_data = Path(site.getsitepackages()[-1]) / 'spyder'
 parso_grammar = (Path(site.getsitepackages()[-1]) / 'parso/python').glob('grammar*')
 
 if sys.platform == 'linux':
-    oce_dir = Path(sys.prefix) / 'share' / 'oce-0.18'
-else:
-    oce_dir = Path(sys.prefix) / 'Library' / 'share' / 'oce'
+    occt_dir = os.path.join(Path(sys.prefix), 'share', 'opencascade')
+    ocp_path = (os.path.join(HOMEPATH, 'OCP.cpython-38-x86_64-linux-gnu.so'), '.')
+elif sys.platform == 'darwin':
+    occt_dir = os.path.join(Path(sys.prefix), 'Library', 'share', 'opencascade')
+    ocp_path = (os.path.join(HOMEPATH, 'OCP.cpython-38-darwin.so'), '.')
+elif sys.platform == 'win32':
+    occt_dir = os.path.join(Path(sys.prefix), 'Library', 'share', 'opencascade')
+    ocp_path = (os.path.join(HOMEPATH, 'OCP.cp38-win_amd64.pyd'), '.')
 
 a = Analysis(['run.py'],
-             pathex=['/home/adam/cq/CQ-editor'],
+             pathex=['.'],
              binaries=[],
              datas=[(spyder_data, 'spyder'),
-                    (oce_dir, 'oce')] +
+                    (occt_dir, 'ocp_path')] +
                     [(p, 'parso/python') for p in parso_grammar],
              hiddenimports=['ipykernel.datapub'],
              hookspath=[],

--- a/pyinstaller/pyi_rth_occ.py
+++ b/pyinstaller/pyi_rth_occ.py
@@ -1,7 +1,7 @@
 from os import environ as env
 
-env['CASROOT'] = 'oce'
+env['CASROOT'] = 'opencascade'
 
-env['CSF_ShadersDirectory'] = 'oce/src/Shaders'
-env['CSF_UnitsLexicon'] = 'oce/src/UnitsAPI/Lexi_Expr.dat'
-env['CSF_UnitsDefinition'] = 'oce/src/UnitsAPI/Units.dat'
+env['CSF_ShadersDirectory'] = 'opencascade/src/Shaders'
+env['CSF_UnitsLexicon'] = 'opencascade/src/UnitsAPI/Lexi_Expr.dat'
+env['CSF_UnitsDefinition'] = 'opencascade/src/UnitsAPI/Units.dat'


### PR DESCRIPTION
This updated spec works for me on Ubuntu 18.04, Windows 10 and MacOS Catalina. There are a couple of gotchas though.
* On Windows, the [redistributable for Visual Studio](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads) needs to be installed. This was the case in the OCE days as well I believe.
* On MacOS there is an issue with the version of PyQt5 (5.9.2) that is installed via conda that keeps the cocoa plugin from loading. Running `pip install PyQt5` in the CQ-editor environment before running pyinstaller fixes this.

@adam-urbanczyk Would you be willing to accept a PR (or an update to this PR) that does a one-click build of all three platforms using GitHub Actions? I've got the same setup working for cq-cli.
Workflow (may only be visible to members of the CadQuery org): https://github.com/CadQuery/cq-cli/actions?query=workflow%3Abuild
Build workflow yaml file: https://github.com/CadQuery/cq-cli/blob/main/.github/workflows/pyinstaller-builds-actions.yml

The Actions build attaches the finished builds as zipped artifacts that you can then download and attach to a release, distribute, etc.