### PR TITLE
Set window title to filename

### DIFF
--- a/cq_editor/main_window.py
+++ b/cq_editor/main_window.py
@@ -22,7 +22,7 @@ from .preferences import PreferencesWidget
 
 class MainWindow(QMainWindow,MainMixin):
 
-    name = 'CQ GUI'
+    name = 'CQ-Editor'
     org = 'CadQuery'
 
     def __init__(self,parent=None):
@@ -329,8 +329,8 @@ class MainWindow(QMainWindow,MainMixin):
 
     def handle_filename_change(self, fname):
 
-        new_title = fname if fname else "CQ-Editor"
-        self.setWindowTitle(new_title)
+        new_title = fname if fname else "*"
+        self.setWindowTitle("{self.name}: {new_title}")
 
 if __name__ == "__main__":
 

--- a/cq_editor/main_window.py
+++ b/cq_editor/main_window.py
@@ -258,6 +258,8 @@ class MainWindow(QMainWindow,MainMixin):
         # trigger re-render when file is modified externally or saved
         self.components['editor'].triggerRerender \
             .connect(self.components['debugger'].render)
+        self.components['editor'].sigFilenameChanged\
+            .connect(self.handle_filename_change)
 
     def prepare_console(self):
 
@@ -324,6 +326,11 @@ class MainWindow(QMainWindow,MainMixin):
     def cq_documentation(self):
 
         open_url('https://cadquery.readthedocs.io/en/latest/')
+
+    def handle_filename_change(self, fname):
+
+        new_title = fname if fname else "CQ-Editor"
+        self.setWindowTitle(new_title)
 
 if __name__ == "__main__":
 

--- a/cq_editor/main_window.py
+++ b/cq_editor/main_window.py
@@ -330,7 +330,7 @@ class MainWindow(QMainWindow,MainMixin):
     def handle_filename_change(self, fname):
 
         new_title = fname if fname else "*"
-        self.setWindowTitle("{self.name}: {new_title}")
+        self.setWindowTitle(f"{self.name}: {new_title}")
 
 if __name__ == "__main__":
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1169,3 +1169,28 @@ def test_render_assy(main):
     console.execute('show(assy)')
     qtbot.wait(500)
     assert(obj_tree_comp.CQ.childCount() == 2)
+
+
+def test_window_title(monkeypatch, main):
+
+    fname = 'test_window_title.py'
+
+    with open(fname, 'w') as f:
+        f.write(code)
+
+    qtbot, win = main
+
+    #monkeypatch QFileDialog methods
+    def filename(*args, **kwargs):
+        return fname, None
+
+    monkeypatch.setattr(QFileDialog, 'getOpenFileName',
+                        staticmethod(filename))
+
+    win.components["editor"].open()
+    assert(win.windowTitle().endswith(fname))
+
+    # handle a new file
+    win.components["editor"].new()
+    # I don't really care what the title is, as long as it's not a filename
+    assert(not win.windowTitle().endswith('.py'))


### PR DESCRIPTION
I think you actually always intended to do this, the signal was already set up, I just wrote a handler and connected it.

![screenshot2021-02-17-094349](https://user-images.githubusercontent.com/50230945/108133577-b7a84c00-7104-11eb-9e21-2e5992ff527a.png)

I haven't run the tests locally because it's a small change and I suck at setting up the PyQt5 test environment. Crossing my fingers while the CI runs them!