### PR TITLE
Status bar messages to indicate rendering and viewing progress

### DIFF
--- a/cq_editor/main_window.py
+++ b/cq_editor/main_window.py
@@ -347,10 +347,12 @@ class MainWindow(QMainWindow,MainMixin):
         self.setWindowTitle(f"{self.name}: {new_title}")
 
     def on_idle(self):
+        self.components['debugger'].set_rendering_state(False)
         self.set_status_message('Idle', '#000000')
 
     @pyqtSlot()
     def on_render_start(self):
+        self.components['debugger'].set_rendering_state(True)
         self.set_status_message('Rendering...', '#ff0000')
 
     @pyqtSlot(int, int, str)

--- a/cq_editor/widgets/debugger.py
+++ b/cq_editor/widgets/debugger.py
@@ -110,6 +110,7 @@ class Debugger(QObject,ComponentMixin):
         {'name': 'Change working dir to script dir','type': 'bool', 'value': True}])
 
 
+    sigRenderStarted = pyqtSignal()
     sigRendered = pyqtSignal(dict)
     sigLocals = pyqtSignal(dict)
     sigTraceback = pyqtSignal(object,str)
@@ -221,6 +222,7 @@ class Debugger(QObject,ComponentMixin):
 
     @pyqtSlot(bool)
     def render(self):
+        self.sigRenderStarted.emit()
 
         if self.preferences['Reload CQ']:
             reload_cq()

--- a/cq_editor/widgets/debugger.py
+++ b/cq_editor/widgets/debugger.py
@@ -251,7 +251,12 @@ class Debugger(QObject,ComponentMixin):
             exc_info = sys.exc_info()
             sys.last_traceback = exc_info[-1]
             self.sigTraceback.emit(exc_info, cq_script)
-    
+
+    def set_rendering_state(self, rendering):
+        render_action = self._actions['Run'][0]
+        render_action.setCheckable(rendering)
+        render_action.setChecked(rendering)
+
     @property
     def breakpoints(self):
         return [ el[0] for el in self.get_breakpoints()]

--- a/cq_editor/widgets/object_tree.py
+++ b/cq_editor/widgets/object_tree.py
@@ -293,7 +293,7 @@ class ObjectTree(QWidget,ComponentMixin):
                                      ais=ais,
                                      sig=self.sigObjectPropertiesChanged))
 
-        self.sigObjectsAdded.emit([ais], name)
+        self.sigObjectsAdded.emit([ais], [name])
 
     @pyqtSlot(list)
     @pyqtSlot()

--- a/cq_editor/widgets/object_tree.py
+++ b/cq_editor/widgets/object_tree.py
@@ -91,7 +91,7 @@ class ObjectTree(QWidget,ComponentMixin):
         {'name': 'Clear all before each run', 'type': 'bool', 'value': True},
         {'name': 'STL precision','type': 'float', 'value': .1}])
 
-    sigObjectsAdded = pyqtSignal([list],[list,bool])
+    sigObjectsAdded = pyqtSignal([list, list],[list, bool, list])
     sigObjectsRemoved = pyqtSignal(list)
     sigCQObjectSelected = pyqtSignal(object)
     sigAISObjectsSelected = pyqtSignal(list)
@@ -195,6 +195,7 @@ class ObjectTree(QWidget,ComponentMixin):
 
         origin = (0,0,0)
         ais_list = []
+        names = []
 
         for name,color,direction in zip(('X','Y','Z'),
                                         ('red','lawngreen','blue'),
@@ -208,8 +209,9 @@ class ObjectTree(QWidget,ComponentMixin):
                                                  ais=line))
 
             ais_list.append(line)
+            names.append(name)
 
-        self.sigObjectsAdded.emit(ais_list)
+        self.sigObjectsAdded.emit(ais_list, names)
 
     def _current_properties(self):
 
@@ -242,6 +244,7 @@ class ObjectTree(QWidget,ComponentMixin):
             self.removeObjects()
 
         ais_list = []
+        names = []
 
         #remove empty objects
         objects_f = {k:v for k,v in objects.items() if not is_obj_empty(v.shape)}
@@ -260,20 +263,21 @@ class ObjectTree(QWidget,ComponentMixin):
             
             if child.properties['Visible']:
                 ais_list.append(ais)
-            
+                names.append(name)
+
             root.addChild(child)
 
         if request_fit_view:
-            self.sigObjectsAdded[list,bool].emit(ais_list,True)
+            self.sigObjectsAdded[list, bool, list].emit(ais_list, True, names)
         else:
-            self.sigObjectsAdded[list].emit(ais_list)
+            self.sigObjectsAdded[list, list].emit(ais_list, names)
 
     @pyqtSlot(object,str,object)
     def addObject(self,obj,name='',options={}):
 
         root = self.CQ
 
-        ais,shape_display = make_AIS(obj, options)
+        ais, shape_display = make_AIS(obj, options)
 
         root.addChild(ObjectTreeItem(name,
                                      shape=obj,
@@ -281,7 +285,7 @@ class ObjectTree(QWidget,ComponentMixin):
                                      ais=ais,
                                      sig=self.sigObjectPropertiesChanged))
 
-        self.sigObjectsAdded.emit([ais])
+        self.sigObjectsAdded.emit([ais], name)
 
     @pyqtSlot(list)
     @pyqtSlot()
@@ -305,7 +309,7 @@ class ObjectTree(QWidget,ComponentMixin):
             self.removeObjects()
             self.CQ.addChildren(self._stash)
             ais_list = [el.ais for el in self._stash]
-            self.sigObjectsAdded.emit(ais_list)
+            self.sigObjectsAdded.emit(ais_list, [''] * len(ais_list))
 
     @pyqtSlot()
     def removeSelected(self):

--- a/cq_editor/widgets/traceback_viewer.py
+++ b/cq_editor/widgets/traceback_viewer.py
@@ -35,8 +35,7 @@ class TracebackPane(QWidget,ComponentMixin):
         
         self.tree = TracebackTree(self)
         self.current_exception = QLabel(self)
-        self.current_exception.setStyleSheet(\
-            "QLabel {color : red; }");
+        self.current_exception.setStyleSheet("QLabel {color : red; }");
         
         layout(self,
                (self.current_exception,

--- a/cq_editor/widgets/viewer.py
+++ b/cq_editor/widgets/viewer.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from typing import List, Optional
 from PyQt5.QtWidgets import (QWidget, QPushButton, QDialog, QTreeWidget,
                              QTreeWidgetItem, QVBoxLayout, QFileDialog,
                              QHBoxLayout, QFrame, QLabel, QApplication,
@@ -45,6 +46,7 @@ class OCCViewer(QWidget,ComponentMixin):
     IMAGE_EXTENSIONS = 'png'
 
     sigObjectSelected = pyqtSignal(list)
+    sigDisplayProgress = pyqtSignal(int, int, str)
 
     def __init__(self,parent=None):
 
@@ -140,31 +142,23 @@ class OCCViewer(QWidget,ComponentMixin):
         context.PurgeDisplay()
         context.RemoveAll(True)
 
-    def _display(self,shape):
-
-        ais = make_AIS(shape)
-        self.canvas.context.Display(shape,True)
-
-        self.displayed_shapes.append(shape)
-        self.displayed_ais.append(ais)
-
-        #self.canvas._display.Repaint()
-
     @pyqtSlot(object)
-    def display(self,ais):
-
-        context = self._get_context()
-        context.Display(ais,True)
-
-        if self.preferences['Fit automatically']: self.fit()
+    def display(self, ais):
+        self.display_many([ais])
 
     @pyqtSlot(list)
-    @pyqtSlot(list,bool)
-    def display_many(self,ais_list,fit=None):
+    @pyqtSlot(list, bool, list)
+    def display_many(self, ais_list, fit: Optional[bool] = None, names: Optional[List] = None):
+        if names is None:
+            names = [None] * len(ais_list)
+        assert len(ais_list) == len(names)
 
         context = self._get_context()
-        for ais in ais_list:
-            context.Display(ais,True)
+        num_objects = len(ais_list)
+        for i, (ais, name) in enumerate(zip(ais_list, names)):
+            self.sigDisplayProgress.emit(i, num_objects, name)
+            context.Display(ais, True)
+        self.sigDisplayProgress.emit(num_objects, num_objects, None)
 
         if self.preferences['Fit automatically'] and fit is None:
             self.fit()
@@ -184,7 +178,8 @@ class OCCViewer(QWidget,ComponentMixin):
     def remove_items(self,ais_items):
 
         ctx = self._get_context()
-        for ais in ais_items: ctx.Erase(ais,True)
+        for ais in ais_items:
+            ctx.Erase(ais,True)
 
     @pyqtSlot()
     def redraw(self):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -747,9 +747,10 @@ def test_console(main):
     assert(len(a) == 1)
 
     # test print_text
-    pos_orig = console._prompt_pos
-    console.print_text('a')
-    assert(console._prompt_pos == pos_orig + len('a'))
+    text_before = console._control.document().toPlainText()
+    console.print_text('foo')
+    text_after = console._control.document().toPlainText()
+    assert text_after == text_before + 'foo'
 
 def test_viewer(main):
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,8 @@
 from path import Path
 import os, sys, asyncio
 
+from pytestqt.qtbot import QtBot
+
 if sys.platform == 'win32':
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
@@ -124,7 +126,7 @@ def get_rgba(ais):
     return color.redF(), color.greenF(), color.blueF(), alpha
 
 @pytest.fixture
-def main(qtbot,mocker):
+def main(qtbot: QtBot, mocker):
 
     mocker.patch.object(QMessageBox, 'question', return_value=QMessageBox.Yes)
 
@@ -142,15 +144,14 @@ def main(qtbot,mocker):
     return qtbot, win
 
 @pytest.fixture
-def main_clean(qtbot,mocker):
+def main_clean(qtbot: QtBot, mocker):
 
     mocker.patch.object(QMessageBox, 'question', return_value=QMessageBox.Yes)
 
     win = MainWindow()
-    win.show()
-
     qtbot.addWidget(win)
-    qtbot.waitForWindowShown(win)
+    with qtbot.waitExposed(win):
+        win.show()
 
     editor = win.components['editor']
     editor.set_text(code)
@@ -158,15 +159,14 @@ def main_clean(qtbot,mocker):
     return qtbot, win
 
 @pytest.fixture
-def main_clean_do_not_close(qtbot,mocker):
+def main_clean_do_not_close(qtbot: QtBot, mocker):
 
     mocker.patch.object(QMessageBox, 'question', return_value=QMessageBox.No)
 
     win = MainWindow()
-    win.show()
-
     qtbot.addWidget(win)
-    qtbot.waitForWindowShown(win)
+    with qtbot.waitExposed(win):
+        win.show()
 
     editor = win.components['editor']
     editor.set_text(code)
@@ -174,16 +174,15 @@ def main_clean_do_not_close(qtbot,mocker):
     return qtbot, win
 
 @pytest.fixture
-def main_multi(qtbot,mocker):
+def main_multi(qtbot: QtBot, mocker):
 
     mocker.patch.object(QMessageBox, 'question', return_value=QMessageBox.Yes)
     mocker.patch.object(QFileDialog, 'getSaveFileName', return_value=('out.step',''))
 
     win = MainWindow()
-    win.show()
-
     qtbot.addWidget(win)
-    qtbot.waitForWindowShown(win)
+    with qtbot.waitExposed(win):
+        win.show()
 
     editor = win.components['editor']
     editor.set_text(code_multi)
@@ -571,7 +570,7 @@ def test_traceback(main):
     assert(traceback_view.tree.root.childCount() == 3) # 1 in user code + 2 in CQ code
 
 @pytest.fixture
-def editor(qtbot):
+def editor(qtbot: QtBot):
 
     win = Editor()
     win.show()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,6 +2,7 @@ from path import Path
 import os, sys, asyncio
 
 from pytestqt.qtbot import QtBot
+import pytestqt.exceptions
 
 if sys.platform == 'win32':
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
@@ -93,6 +94,8 @@ a = cq.Assembly().add(sh)
 sk = cq.Sketch().rect(1,1)
 """
 
+TIMEOUT = 10_000
+
 def _modify_file(code, path="test.py"):
     with open(path, "w", 1) as f:
         f.write(code)
@@ -150,7 +153,7 @@ def main_clean(qtbot: QtBot, mocker):
 
     win = MainWindow()
     qtbot.addWidget(win)
-    with qtbot.waitExposed(win):
+    with qtbot.waitExposed(win, timeout=TIMEOUT):
         win.show()
 
     editor = win.components['editor']
@@ -165,7 +168,7 @@ def main_clean_do_not_close(qtbot: QtBot, mocker):
 
     win = MainWindow()
     qtbot.addWidget(win)
-    with qtbot.waitExposed(win):
+    with qtbot.waitExposed(win, timeout=TIMEOUT):
         win.show()
 
     editor = win.components['editor']
@@ -181,7 +184,7 @@ def main_multi(qtbot: QtBot, mocker):
 
     win = MainWindow()
     qtbot.addWidget(win)
-    with qtbot.waitExposed(win):
+    with qtbot.waitExposed(win, timeout=TIMEOUT):
         win.show()
 
     editor = win.components['editor']
@@ -662,8 +665,6 @@ def test_editor_autoreload(monkeypatch,editor):
 
     qtbot, editor = editor
 
-    TIMEOUT = 500
-
     # start out with autoreload enabled
     editor.autoreload(True)
 
@@ -712,7 +713,6 @@ def test_autoreload_nested(editor):
 
     qtbot, editor = editor
 
-    TIMEOUT = 500
 
     editor.autoreload(True)
     editor.preferences['Autoreload: watch imported modules'] = True
@@ -1440,7 +1440,6 @@ def makebox(z):
 
 def test_reload_import_handle_error(tmp_path, main):
 
-    TIMEOUT = 500
     qtbot, win = main
     editor = win.components["editor"]
     debugger = win.components["debugger"]
@@ -1481,7 +1480,6 @@ def test_reload_import_handle_error(tmp_path, main):
 
 def test_modulefinder(tmp_path, main):
 
-    TIMEOUT = 500
     qtbot, win = main
     editor = win.components["editor"]
     debugger = win.components["debugger"]


### PR DESCRIPTION
since the application doesn't look visually different when it is rendering/drawing and when you can interact with it, I think it would be useful if there was some way to determine if CQ-Editor is currently busy at a glance. The status bar isn't currently being used for anything so I used that to display messages:
```python
time.sleep(1.5)  # to simulate a long running script
sphere = cq.Workplane('XY').move(6, 6).sphere(3)
loft = cq.Workplane('XY').ellipse(5, 7).workplane(5).circle(4).workplane(5).ellipse(7, 5).loft()
box = cq.Workplane('XY').move(-8, -2).box(3, 4, 2)

show_object(loft, 'my_loft')
show_object(sphere, 'my_sphere')
show_object(box, 'my_box')
```
https://user-images.githubusercontent.com/4923501/108626297-4c81b100-7447-11eb-806c-0af038f160d2.mp4

