### PR TITLE
Multi module support

### DIFF
--- a/cq_editor/widgets/debugger.py
+++ b/cq_editor/widgets/debugger.py
@@ -104,7 +104,7 @@ class Debugger(QObject,ComponentMixin):
         {'name': 'Reload CQ', 'type': 'bool', 'value': False},
         {'name': 'Add script dir to path','type': 'bool', 'value': True},
         {'name': 'Change working dir to script dir','type': 'bool', 'value': True},
-        {'name': 'Cache imported modules', 'type': 'bool', 'value': False},
+        {'name': 'Reload imported modules', 'type': 'bool', 'value': True},
     ])
 
 
@@ -187,8 +187,8 @@ class Debugger(QObject,ComponentMixin):
                 stack.callback(sys.path.remove, p)
             if self.preferences['Change working dir to script dir'] and p.exists():
                 stack.enter_context(p)
-            if not self.preferences['Cache imported modules']:
-                stack.enter_context(module_environment())
+            if self.preferences['Reload imported modules']:
+                stack.enter_context(module_manager())
 
             exec(code, locals_dict, globals_dict)     
 
@@ -353,7 +353,7 @@ class Debugger(QObject,ComponentMixin):
 
 
 @contextmanager
-def module_environment():
+def module_manager():
     """ unloads any modules loaded while the context manager is active """
     loaded_modules = set(sys.modules.keys())
     yield

--- a/cq_editor/widgets/debugger.py
+++ b/cq_editor/widgets/debugger.py
@@ -103,7 +103,9 @@ class Debugger(QObject,ComponentMixin):
     preferences = Parameter.create(name='Preferences',children=[
         {'name': 'Reload CQ', 'type': 'bool', 'value': False},
         {'name': 'Add script dir to path','type': 'bool', 'value': True},
-        {'name': 'Change working dir to script dir','type': 'bool', 'value': True}])
+        {'name': 'Change working dir to script dir','type': 'bool', 'value': True},
+        {'name': 'Cache imported modules', 'type': 'bool', 'value': False},
+    ])
 
 
     sigRendered = pyqtSignal(dict)
@@ -185,7 +187,8 @@ class Debugger(QObject,ComponentMixin):
                 stack.callback(sys.path.remove, p)
             if self.preferences['Change working dir to script dir'] and p.exists():
                 stack.enter_context(p)
-            stack.enter_context(module_environment())
+            if not self.preferences['Cache imported modules']:
+                stack.enter_context(module_environment())
 
             exec(code, locals_dict, globals_dict)     
 

--- a/cq_editor/widgets/editor.py
+++ b/cq_editor/widgets/editor.py
@@ -1,3 +1,6 @@
+import os
+from modulefinder import ModuleFinder
+
 from spyder.plugins.editor.widgets.codeeditor import CodeEditor
 from PyQt5.QtCore import pyqtSignal, QFileSystemWatcher, QTimer
 from PyQt5.QtWidgets import QAction, QFileDialog
@@ -156,14 +159,14 @@ class Editor(CodeEditor,ComponentMixin):
         if self._filename != '':
 
             if self.preferences['Autoreload']:
-                self._file_watcher.removePath(self.filename)
+                self._file_watcher.blockSignals(True)
                 self._file_watch_timer.stop()
 
-            with open(self._filename,'w') as f:
+            with open(self._filename, 'w') as f:
                 f.write(self.toPlainText())
 
             if self.preferences['Autoreload']:
-                self._file_watcher.addPath(self.filename)
+                self._file_watcher.blockSignals(False)
                 self.triggerRerender.emit(True)
 
             self.reset_modified()
@@ -183,15 +186,15 @@ class Editor(CodeEditor,ComponentMixin):
 
     def _update_filewatcher(self):
         if self._watched_file and (self._watched_file != self.filename or not self.preferences['Autoreload']):
-            self._file_watcher.removePath(self._watched_file)
+            self._file_watcher.removePaths(self._file_watcher.files())
             self._watched_file = None
         if self.preferences['Autoreload'] and self.filename and self.filename != self._watched_file:
             self._watched_file = self._filename
-            self._file_watcher.addPath(self.filename)
+            self._watch_paths()
 
     @property
     def filename(self):
-      return self._filename
+        return self._filename
 
     @filename.setter
     def filename(self, fname):
@@ -199,11 +202,14 @@ class Editor(CodeEditor,ComponentMixin):
         self._update_filewatcher()
         self.sigFilenameChanged.emit(fname)
 
+    def _watch_paths(self):
+        self._file_watcher.addPath(self._filename)
+        self._file_watcher.addPaths(get_imported_module_paths(self._filename))
+
     # callback triggered by QFileSystemWatcher
     def _file_changed(self):
-        # neovim writes a file by removing it first
-        # this causes QFileSystemWatcher to forget the file
-        self._file_watcher.addPath(self._filename)
+        # neovim writes a file by removing it first so must re-add each time
+        self._watch_paths()
         self.set_text_from_file(self._filename)
         self.triggerRerender.emit(True)
 
@@ -235,6 +241,19 @@ class Editor(CodeEditor,ComponentMixin):
                 self.load_from_file(filename)
             except IOError:
                 self._logger.warning(f'could not open {filename}')
+
+
+def get_imported_module_paths(module_path):
+    finder = ModuleFinder([os.path.dirname(module_path)])
+    finder.run_script(module_path)
+    imported_modules = []
+    for module_name, module in finder.modules.items():
+        if module_name != '__main__':
+            path = getattr(module, '__file__', None)
+            if path is not None and os.path.isfile(path):
+                imported_modules.append(path)
+    return imported_modules
+
 
 if __name__ == "__main__":
 

--- a/cqgui_env.yml
+++ b/cqgui_env.yml
@@ -17,6 +17,7 @@ dependencies:
   - typing_extensions
   - scipy
   - nptyping
+  - nlopt
   - pip
   - pip:
     - "https://github.com/CadQuery/cadquery/archive/master.zip"

--- a/run.py
+++ b/run.py
@@ -11,4 +11,6 @@ if sys.platform == 'win32':
 
 from cq_editor.__main__ import main
 
-main()
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -73,7 +73,7 @@ result1 = cq.Workplane("XY" ).box(3, 3, 0.5)
 result2 = cq.Workplane("XY" ).box(3, 3, 0.5).translate((0,15,0))
 '''
 
-code_nested_top = """import bottom
+code_nested_top = """import test_nested_bottom
 """
 
 code_nested_bottom = """a=1

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -73,12 +73,19 @@ result1 = cq.Workplane("XY" ).box(3, 3, 0.5)
 result2 = cq.Workplane("XY" ).box(3, 3, 0.5).translate((0,15,0))
 '''
 
-def _modify_file(code):
-        with open('test.py', 'w', 1) as f:
-                    f.write(code)
+code_nested_top = """import bottom
+"""
 
-def modify_file(code):
-    p = Process(target=_modify_file,args=(code,))
+code_nested_bottom = """a=1
+"""
+
+def _modify_file(code, path="test.py"):
+    with open(path, "w", 1) as f:
+        f.write(code)
+
+
+def modify_file(code, path="test.py"):
+    p = Process(target=_modify_file, args=(code,path))
     p.start()
     p.join()
 
@@ -645,6 +652,30 @@ def test_editor_autoreload(monkeypatch,editor):
     # Saving a file with autoreload enabled should trigger a rerender.
     with qtbot.waitSignal(editor.triggerRerender, timeout=TIMEOUT):
         editor.save()
+        
+def test_autoreload_nested(editor):
+    
+    qtbot, editor = editor
+
+    TIMEOUT = 500
+
+    editor.preferences['Autoreload: watch imported modules'] = True
+
+    with open('test_nested_top.py','w') as f:
+        f.write(code_nested_top)
+
+    with open('test_nested_bottom.py','w') as f:
+        f.write("")
+
+    assert(editor.get_text_with_eol() == '')
+
+    editor.load_from_file('test_nested_top.py')
+    assert(len(editor.get_text_with_eol()) > 0)
+
+    # wait for reload.
+    with qtbot.waitSignal(editor.triggerRerender, timeout=TIMEOUT):
+        # modify file - NB: separate process is needed to avoid Widows quirks
+        modify_file(code_nested_bottom, 'test_nested_bottom.py')
 
 def test_console(main):
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -14,7 +14,7 @@ from PyQt5.QtCore import Qt, QSettings
 from PyQt5.QtWidgets import QFileDialog, QMessageBox
 
 from cq_editor.__main__ import MainWindow
-from cq_editor.widgets.editor import Editor
+from cq_editor.widgets.editor import Editor, get_imported_module_paths
 from cq_editor.cq_utils import export, get_occ_color
 
 code = \
@@ -1253,3 +1253,14 @@ def test_window_title(monkeypatch, main):
     win.components["editor"].new()
     # I don't really care what the title is, as long as it's not a filename
     assert(not win.windowTitle().endswith('.py'))
+
+
+def test_module_discovery(tmp_path):
+    with open(tmp_path.joinpath('main.py'), 'w') as f:
+        f.write('import b')
+
+    assert get_imported_module_paths(str(tmp_path.joinpath('main.py'))) == []
+
+    tmp_path.joinpath('b.py').touch()
+
+    assert get_imported_module_paths(str(tmp_path.joinpath('main.py'))) == [str(tmp_path.joinpath('b.py'))]


### PR DESCRIPTION
I have added support for a multi-module workflow to CQ-Editor by:
- removing modules that are imported by the main module (otherwise the parts from the non-main modules will never update as their modules are cached by the interpreter since the scripts and the editor run in the same interpreter)
- searching for and watching the paths of any modules imported by the main module, and triggering a re-render whenever any of the watched files are changed

I'm not sure if this is a common workflow (likely it won't be since the tooling doesn't support it well) but if I want to create a complex part with multiple components, I might want to have separate modules where I design each part in a stand-alone module which can be run to create just that part, and a main script which assembles everything together.


https://user-images.githubusercontent.com/4923501/122648607-e9b4d380-d121-11eb-8646-8e09377834ef.mp4


https://user-images.githubusercontent.com/4923501/122648611-ecafc400-d121-11eb-9073-f9c6407ed7ec.mp4

