### PR TITLE
Fix test autoreload_nested to be independent of other tests

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -659,6 +659,7 @@ def test_autoreload_nested(editor):
 
     TIMEOUT = 500
 
+    editor.autoreload(True)
     editor.preferences['Autoreload: watch imported modules'] = True
 
     with open('test_nested_top.py','w') as f:
@@ -674,7 +675,7 @@ def test_autoreload_nested(editor):
 
     # wait for reload.
     with qtbot.waitSignal(editor.triggerRerender, timeout=TIMEOUT):
-        # modify file - NB: separate process is needed to avoid Widows quirks
+        # modify file - NB: separate process is needed to avoid Windows quirks
         modify_file(code_nested_bottom, 'test_nested_bottom.py')
 
 def test_console(main):


### PR DESCRIPTION
I ran the CQ-editor tests today for the first time as I'd like to make a PR for a separate issue. I found that the autoreload_nested test failed when run standalone:

```$ pytest -k autoreload_nested```

The test had passed when run together with the other tests.  A previous test was setting the Autoreload preference to True, without which, auto rerender does not occur (as expected).  This test must have Autoreload True in order to pass.