### PR TITLE
Update test_export.  Ensure the focus is set on the correct item.

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -249,8 +249,16 @@ def test_export(main,mocker):
     obj_tree = win.components['object_tree'].tree
     obj_tree_comp = win.components['object_tree']
     qtbot.mouseClick(obj_tree, Qt.LeftButton)
-    qtbot.keyClick(obj_tree, Qt.Key_Down)
-    qtbot.keyClick(obj_tree, Qt.Key_Down)
+    if len(obj_tree_comp.tree.selectedItems()) == 0:
+        qtbot.keyClick(obj_tree, Qt.Key_Down)
+    item = obj_tree_comp.tree.selectedItems()[0]
+    if item.text(0) == "CQ models":
+        qtbot.keyClick(obj_tree, Qt.Key_Down)
+        item = obj_tree_comp.tree.selectedItems()[0]
+    elif item.text(0) == "Helpers":
+        qtbot.keyClick(obj_tree, Qt.Key_Up)
+        item = obj_tree_comp.tree.selectedItems()[0]
+    assert(item.text(0) == "result")
 
     #export STL
     mocker.patch.object(QFileDialog, 'getSaveFileName', return_value=('out.stl',''))


### PR DESCRIPTION

test_export was failing for me.  Two Key_Down calls resulted in export of the wrong tree item (Helpers not result):
    <cq_editor.widgets.object_tree.HelpersRootItem object at 0x7fd257e483a0>

Perhaps the qtbot selection is fragile.  I've made a change so the item is correctly selected for export if the initial focus happens to be "CQ models" or the "Helpers" rows.