### PR TITLE
Fix AppVeyor build failure

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ image:
 #    - macOS-mojave
 #    - macOS
 #    - Ubuntu
-#    - Ubuntu2004
+    - Ubuntu2004
     - Ubuntu1804
     - Visual Studio 2015
 


### PR DESCRIPTION
* Do not pin pyvirtualdisplay

* Disable redundant Ubuntu 18.04 build

Builds are successful:
[Ubuntu 18.04 log](https://ci.appveyor.com/project/lorenzncode/cq-editor/builds/41261313/job/ftnvyh8sa9govk50) 
[Windows log](https://ci.appveyor.com/project/lorenzncode/cq-editor/builds/41261313/job/v6k9mck1hi572c20)
