### PR TITLE
Handle exception when watching imported modules

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ jobs:
     vmImage: 'ubuntu-18.04'
     py_maj: 3
     py_min: 8
-    conda_bld: '3.20.3'
+    conda_bld: 3.21.6
 
 - template: conda-build.yml@templates
   parameters:
@@ -29,7 +29,7 @@ jobs:
     vmImage: 'macOS-10.15'
     py_maj: 3
     py_min: 8
-    conda_bld: '3.20.3'
+    conda_bld: 3.21.6
 
 - template: conda-build.yml@templates
   parameters:
@@ -37,7 +37,7 @@ jobs:
     vmImage: 'vs2017-win2016'
     py_maj: 3
     py_min: 8
-    conda_bld: '3.20.3'
+    conda_bld: 3.21.6
 
 - template: conda-build.yml@templates
   parameters:
@@ -45,7 +45,7 @@ jobs:
     vmImage: 'ubuntu-18.04'
     py_maj: 3
     py_min: 9
-    conda_bld: '3.21.4'
+    conda_bld: 3.21.6
 
 - template: conda-build.yml@templates
   parameters:
@@ -53,7 +53,7 @@ jobs:
     vmImage: 'macOS-10.15'
     py_maj: 3
     py_min: 9
-    conda_bld: '3.21.4'
+    conda_bld: 3.21.6
 
 - template: conda-build.yml@templates
   parameters:
@@ -61,4 +61,4 @@ jobs:
     vmImage: 'vs2017-win2016'
     py_maj: 3
     py_min: 9
-    conda_bld: '3.21.4'
+    conda_bld: 3.21.6

--- a/cq_editor/widgets/debugger.py
+++ b/cq_editor/widgets/debugger.py
@@ -356,7 +356,10 @@ class Debugger(QObject,ComponentMixin):
 def module_manager():
     """ unloads any modules loaded while the context manager is active """
     loaded_modules = set(sys.modules.keys())
-    yield
-    new_modules = set(sys.modules.keys()) - loaded_modules
-    for module_name in new_modules:
-        del sys.modules[module_name]
+
+    try:
+        yield
+    finally:
+        new_modules = set(sys.modules.keys()) - loaded_modules
+        for module_name in new_modules:
+            del sys.modules[module_name]


### PR DESCRIPTION
This PR addresses a problem with _Autoreload: watch imported modules_ where changes to a watched module no longer have any effect after an exception.

Say the top level script imports a module:

```
from module_makebox import *
z = 1
r = makebox(z)
```

Where module_makebox.py is:

```
import cadquery as cq
def makebox(z):
    zval = z + 1
    return cq.Workplane().box(1, 1, zval)
```

Changes to the makebox function are reflected in the render of the box model in CQ-editor.

Once an exception occurs in the imported module, CQ-editor will no longer update even after the code is corrected.

The pytest introduces an exception in the module and checks that a rerender is triggered without exception after the module code is corrected.
