### PR TITLE
Handle exceptions when determining imported modules (#312)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,8 +28,8 @@ install:
     - sh: source activate cqgui
     - cmd: activate cqgui
     - mamba list
-    - pip install pytest pluggy pytest-qt
-    - pip install pytest-mock pytest-cov pytest-repeat codecov pyvirtualdisplay
+    - mamba install pytest pluggy pytest-qt
+    - mamba install pytest-mock pytest-cov pytest-repeat codecov pyvirtualdisplay
 
 build: false
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,8 +28,8 @@ install:
     - sh: source activate cqgui
     - cmd: activate cqgui
     - mamba list
-    - mamba install pytest pluggy pytest-qt
-    - mamba install pytest-mock pytest-cov pytest-repeat codecov pyvirtualdisplay
+    - mamba install -y pytest pluggy pytest-qt
+    - mamba install -y pytest-mock pytest-cov pytest-repeat codecov pyvirtualdisplay
 
 build: false
 

--- a/cq_editor/widgets/editor.py
+++ b/cq_editor/widgets/editor.py
@@ -265,6 +265,10 @@ class Editor(CodeEditor,ComponentMixin):
             finder.run_script(module_path)
         except SyntaxError as err:
             self._logger.warning(f'Syntax error in {module_path}: {err}')
+        except Exception as err:
+            self._logger.warning(
+                f'Cannot determine imported modules in {module_path}: {type(err).__name__} {err}'
+            )
         else:
             for module_name, module in finder.modules.items():
                 if module_name != '__main__':

--- a/cq_editor/widgets/editor.py
+++ b/cq_editor/widgets/editor.py
@@ -212,7 +212,7 @@ class Editor(CodeEditor,ComponentMixin):
             self._file_watcher.removePaths(paths)
 
     def _watch_paths(self):
-        if self._filename:
+        if Path(self._filename).exists():
             self._file_watcher.addPath(self._filename)
             if self.preferences['Autoreload: watch imported modules']:
                 module_paths =  self.get_imported_module_paths(self._filename)


### PR DESCRIPTION
This is to resolve #312 where CQ-Editor can get into a state where it does not launch and no error message is issued.