### PR TITLE
Use conda config (config not supported through mamba)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ install:
     - cmd: miniconda.exe /S /InstallationType=JustMe /D=%MINICONDA_DIRNAME%
     - cmd: set "PATH=%MINICONDA_DIRNAME%;%MINICONDA_DIRNAME%\\Scripts;%PATH%"
     - cmd: activate
-    - mamba config --set always_yes yes
+    - conda config --set always_yes yes
     - mamba info
     - mamba env create --name cqgui -f cqgui_env.yml
     - sh: source activate cqgui

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,6 @@ install:
     - cmd: miniconda.exe /S /InstallationType=JustMe /D=%MINICONDA_DIRNAME%
     - cmd: set "PATH=%MINICONDA_DIRNAME%;%MINICONDA_DIRNAME%\\Scripts;%PATH%"
     - cmd: activate
-    - conda config --set always_yes yes
     - mamba info
     - mamba env create --name cqgui -f cqgui_env.yml
     - sh: source activate cqgui


### PR DESCRIPTION
I fetched upstream and read through the git log.  I noticed the recent comment about `mamba config` on windows.

This is also true for Linux.  I had tried `mamba config` before with my local install script and now have it commented out with "# no this is not supported".

I'd suggest to change the line in `appveyor.yml` to:
`conda config --set always_yes yes`

I suppose it is redundant anyway since `mamba install -y` is specified.

miniforge provides the conda command so it can be used for `conda config`.


For example with a miniforge install on Linux (note the "Currently, only install, ... and clear are supported through mamba."):

```
(base) [lorenzn@fedora CQ-editor]$ cat ~/.condarc 
pkgs_dirs:
  - /home/lorenzn/tools/condacache
always_yes: false
(base) [lorenzn@fedora CQ-editor]$ mamba config --set always_yes yes

                  __    __    __    __
                 /  \  /  \  /  \  /  \
                /    \/    \/    \/    \
███████████████/  /██/  /██/  /██/  /████████████████████████
              /  / \   / \   / \   / \  \____
             /  /   \_/   \_/   \_/   \    o \__,
            / _/                       \_____/  `
            |/
        ███╗   ███╗ █████╗ ███╗   ███╗██████╗  █████╗
        ████╗ ████║██╔══██╗████╗ ████║██╔══██╗██╔══██╗
        ██╔████╔██║███████║██╔████╔██║██████╔╝███████║
        ██║╚██╔╝██║██╔══██║██║╚██╔╝██║██╔══██╗██╔══██║
        ██║ ╚═╝ ██║██║  ██║██║ ╚═╝ ██║██████╔╝██║  ██║
        ╚═╝     ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝╚═════╝ ╚═╝  ╚═╝

        mamba (0.19.0) supported by @QuantStack

        GitHub:  https://github.com/mamba-org/mamba
        Twitter: https://twitter.com/QuantStack

█████████████████████████████████████████████████████████████

Currently, only install, create, list, search, run, info and clean are supported through mamba.
(base) [lorenzn@fedora CQ-editor]$ cat ~/.condarc 
pkgs_dirs:
  - /home/lorenzn/tools/condacache
always_yes: false
(base) [lorenzn@fedora CQ-editor]$ conda config --set always_yes yes
(base) [lorenzn@fedora CQ-editor]$ cat ~/.condarc 
pkgs_dirs:
  - /home/lorenzn/tools/condacache
always_yes: true
```
