### PR TITLE
Fix empty dict as default arg

### DIFF
--- a/cq_editor/widgets/object_tree.py
+++ b/cq_editor/widgets/object_tree.py
@@ -269,7 +269,9 @@ class ObjectTree(QWidget,ComponentMixin):
             self.sigObjectsAdded[list].emit(ais_list)
 
     @pyqtSlot(object,str,object)
-    def addObject(self,obj,name='',options={}):
+    def addObject(self,obj,name='',options=None):
+
+        if options is None: options={}
 
         root = self.CQ
 


### PR DESCRIPTION
See e.g. https://towardsdatascience.com/python-pitfall-mutable-default-arguments-9385e8265422

(It happened to me that an object was stubbornly getting color set in previous runs.)