### PR TITLE
Make Render shortcut more discoverable.

### DIFF
--- a/cq_editor/widgets/debugger.py
+++ b/cq_editor/widgets/debugger.py
@@ -129,7 +129,7 @@ class Debugger(QObject,ComponentMixin):
 
         self._actions =  \
             {'Run' : [QAction(icon('run'),
-                              'Render',
+                              'Render (F5)',
                                self,
                                shortcut='F5',
                                triggered=self.render),


### PR DESCRIPTION
When I started using CQ-editor, it took me a while to discover that there was a keyboard shortcut for Render. This patch makes the shortcut more obvious.