### PR TITLE
Add dependencies to setup.py for Pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,4 +26,13 @@ setup(
             "CQ-editor = cq_editor.__main__:main",
         ]
     },
+    python_requires=">=3.8,<3.11",
+    install_requires=[
+        "logbook>=1",
+        "path>=16",
+        "PyQt5>=5",
+        "pyqtgraph==0.12",
+        "requests>=2,<3",
+        "spyder>=5,<6",
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,14 @@ def get_version(rel_path):
     else:
         raise RuntimeError("Unable to find version string.")
 
-setup(name='CQ-editor',
-      version=get_version('cq_editor/_version.py'),
-      packages=find_packages(),
-      entry_points={
-          'gui_scripts': [
-              'cq-editor = cq_editor.__main__:main',
-              'CQ-editor = cq_editor.__main__:main' 
-          ]}
-     )
+setup(
+    name="CQ-editor",
+    version=get_version("cq_editor/_version.py"),
+    packages=find_packages(),
+    entry_points={
+        "gui_scripts": [
+            "cq-editor = cq_editor.__main__:main",
+            "CQ-editor = cq_editor.__main__:main",
+        ]
+    },
+)


### PR DESCRIPTION
Tested on Ubuntu 20.04 with Python 3.9.

## Pip

```
python3.9 -m venv .venv
. .venv/bin/activate
pip install -U pip
pip install git+https://github.com/sethfischer/CQ-editor.git@352-setup-deps
```

## Poetry

Experimental.

```
python3.9 -m venv .venv
. .venv/bin/activate
pip install -U pip
poetry init --name="test" --python=">=3.8,<3.11" --no-interaction
poetry add casadi==3.5.5
poetry add git+https://github.com/sethfischer/CQ-editor.git@352-setup-deps
pip install -U setuptools
```

Closes #352