### PR TITLE
add log() function to the built-in CQ-editor console

### DIFF
--- a/cq_editor/main_window.py
+++ b/cq_editor/main_window.py
@@ -1,7 +1,7 @@
 import sys
 
 from PyQt5.QtWidgets import (QLabel, QMainWindow, QToolBar, QDockWidget, QAction)
-
+from logbook import Logger
 import cadquery as cq
 
 from .widgets.editor import Editor
@@ -267,7 +267,6 @@ class MainWindow(QMainWindow,MainMixin):
 
     def prepare_console(self):
 
-        from logbook import Logger
         console = self.components['console']
         obj_tree = self.components['object_tree']
         

--- a/cq_editor/main_window.py
+++ b/cq_editor/main_window.py
@@ -267,16 +267,18 @@ class MainWindow(QMainWindow,MainMixin):
 
     def prepare_console(self):
 
+        from logbook import Logger
         console = self.components['console']
         obj_tree = self.components['object_tree']
-
+        
         #application related items
         console.push_vars({'self' : self})
 
         #CQ related items
         console.push_vars({'show' : obj_tree.addObject,
                            'show_object' : obj_tree.addObject,
-                           'cq' : cq})
+                           'cq' : cq,
+                           'log' : Logger(self.name).info})
 
     def fill_dummy(self):
 


### PR DESCRIPTION
This is a small commit to add the ability to send output from the CQ-editor console to the built-in Log Viewer: 
![image](https://user-images.githubusercontent.com/16868537/182947603-011144cc-c20d-4aad-b56c-d1d5dfbe2404.png)

I have it set currently to INFO level, which I think is appropriate since it is user-initiated anyway.