### PR TITLE
Reformat Default CQ-Editor Log Output to Reduce Character Width

### DIFF
--- a/cq_editor/widgets/log.py
+++ b/cq_editor/widgets/log.py
@@ -10,7 +10,10 @@ class QtLogHandler(logging.Handler,logging.StringFormatterHandlerMixin):
     def __init__(self, log_widget,*args,**kwargs):
         
         super(QtLogHandler,self).__init__(*args,**kwargs)
-        logging.StringFormatterHandlerMixin.__init__(self,None)
+        
+        log_format_string = '[{record.time:%H:%M:%S.%f%z}] {record.level_name}: {record.message}'
+        
+        logging.StringFormatterHandlerMixin.__init__(self,log_format_string)
         
         self.log_widget = log_widget
 

--- a/cq_editor/widgets/log.py
+++ b/cq_editor/widgets/log.py
@@ -11,7 +11,7 @@ class QtLogHandler(logging.Handler,logging.StringFormatterHandlerMixin):
         
         super(QtLogHandler,self).__init__(*args,**kwargs)
         
-        log_format_string = '[{record.time:%H:%M:%S.%f%z}] {record.level_name}: {record.message}'
+        log_format_string = '[{record.time:%H:%M:%S%z}] {record.level_name}: {record.message}'
         
         logging.StringFormatterHandlerMixin.__init__(self,log_format_string)
         


### PR DESCRIPTION
Added a variable with a new format string to reduce the character width of logging output for better compatibility with smaller screens. Here is a comparison of the old and new format: 

![image](https://user-images.githubusercontent.com/16868537/182954494-33b26a8a-08e5-4c79-9078-676ccb0b5448.png)

Here is a comparison of the default format versus the new format:
```py
default_format_string = '[{record.time:%Y-%m-%d %H:%M:%S.%f%z}] {record.level_name}: {record.channel}: {record.message}'
new_format_string = '[{record.time:%H:%M:%S.%f%z}] {record.level_name}: {record.message}'
```