### PR TITLE
Fix crash caused by default object color 'FF0' to '#FF0'

### DIFF
--- a/cq_editor/widgets/object_tree.py
+++ b/cq_editor/widgets/object_tree.py
@@ -21,7 +21,7 @@ class TopTreeItem(QTreeWidgetItem):
 class ObjectTreeItem(QTreeWidgetItem):
 
     props = [{'name': 'Name', 'type': 'str', 'value': ''},
-             {'name': 'Color', 'type': 'color', 'value': "f4a824"},
+             {'name': 'Color', 'type': 'color', 'value': "#f4a824"},
              {'name': 'Alpha', 'type': 'float', 'value': 0, 'limits': (0,1), 'step': 1e-1},
              {'name': 'Visible', 'type': 'bool','value': True}]
 
@@ -32,7 +32,7 @@ class ObjectTreeItem(QTreeWidgetItem):
                  shape_display=None,
                  sig=None,
                  alpha=0.,
-                 color='f4a824',
+                 color='#f4a824',
                  **kwargs):
 
         super(ObjectTreeItem,self).__init__([name],**kwargs)

--- a/cq_editor/widgets/viewer.py
+++ b/cq_editor/widgets/viewer.py
@@ -38,7 +38,7 @@ class OCCViewer(QWidget,ComponentMixin):
         {'name': 'Use gradient', 'type': 'bool', 'value': False},
         {'name': 'Background color', 'type': 'color', 'value': (95,95,95)},
         {'name': 'Background color (aux)', 'type': 'color', 'value': (30,30,30)},
-        {'name': 'Default object color', 'type': 'color', 'value': "FF0"},
+        {'name': 'Default object color', 'type': 'color', 'value': "#FF0"},
         {'name': 'Deviation', 'type': 'float', 'value': 1e-5, 'dec': True, 'step': 1},
         {'name': 'Angular deviation', 'type': 'float', 'value': 0.1, 'dec': True, 'step': 1},
         {'name': 'Projection Type', 'type': 'list', 'value': 'Orthographic',


### PR DESCRIPTION
See discussion here about the deprecation of 'FF0' as a valid color in pyqtgraph as of version 0.13: https://github.com/pyqtgraph/pyqtgraph/issues/2458

This PR simply prepends the '#' to 'FF0' and prevents a crash if used with pyqtgraph=0.13+ which was released a few days ago. This was previously not an issue using pyqtgraph=0.12.4.