### PR TITLE
Windows Appveyor VS2015 to VS2017

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ shallow_clone: false
 image:
     - Ubuntu2004
     - Ubuntu1804
-    - Visual Studio 2015
+    - Visual Studio 2017
 
 environment:
     matrix:


### PR DESCRIPTION
Visual Studio 2015 is based on Windows Server 2012 R2 which is almost 10 years old now and is based in Win8.1. Bump to Visual Studio 2017 which is based on Win10. 

This recently broke builds with qtawesome=1.2.0, although they have said they will fix and release as 1.2.1.