### PR TITLE
Add a random color function to CQ-editor

### DIFF
--- a/cq_editor/main_window.py
+++ b/cq_editor/main_window.py
@@ -1,7 +1,7 @@
 import sys
 
 from PyQt5.QtWidgets import (QLabel, QMainWindow, QToolBar, QDockWidget, QAction)
-
+from logbook import Logger
 import cadquery as cq
 
 from .widgets.editor import Editor
@@ -267,7 +267,6 @@ class MainWindow(QMainWindow,MainMixin):
 
     def prepare_console(self):
 
-        from logbook import Logger
         console = self.components['console']
         obj_tree = self.components['object_tree']
         

--- a/cq_editor/main_window.py
+++ b/cq_editor/main_window.py
@@ -267,16 +267,18 @@ class MainWindow(QMainWindow,MainMixin):
 
     def prepare_console(self):
 
+        from logbook import Logger
         console = self.components['console']
         obj_tree = self.components['object_tree']
-
+        
         #application related items
         console.push_vars({'self' : self})
 
         #CQ related items
         console.push_vars({'show' : obj_tree.addObject,
                            'show_object' : obj_tree.addObject,
-                           'cq' : cq})
+                           'cq' : cq,
+                           'log' : Logger(self.name).info})
 
     def fill_dummy(self):
 

--- a/cq_editor/main_window.py
+++ b/cq_editor/main_window.py
@@ -276,7 +276,7 @@ class MainWindow(QMainWindow,MainMixin):
         #CQ related items
         console.push_vars({'show' : obj_tree.addObject,
                            'show_object' : obj_tree.addObject,
-                           'rand_color' : self.components['debugger']._rand_color,
+                           'rand_color' : None,#self.components['debugger']._rand_color,
                            'cq' : cq,
                            'log' : Logger(self.name).info})
 

--- a/cq_editor/main_window.py
+++ b/cq_editor/main_window.py
@@ -276,7 +276,7 @@ class MainWindow(QMainWindow,MainMixin):
         #CQ related items
         console.push_vars({'show' : obj_tree.addObject,
                            'show_object' : obj_tree.addObject,
-                           'rand_color' : None,#self.components['debugger']._rand_color,
+                           'rand_color' : self.components['debugger']._rand_color,
                            'cq' : cq,
                            'log' : Logger(self.name).info})
 

--- a/cq_editor/main_window.py
+++ b/cq_editor/main_window.py
@@ -276,6 +276,7 @@ class MainWindow(QMainWindow,MainMixin):
         #CQ related items
         console.push_vars({'show' : obj_tree.addObject,
                            'show_object' : obj_tree.addObject,
+                           'rand_color' : self.components['debugger']._rand_color,
                            'cq' : cq,
                            'log' : Logger(self.name).info})
 

--- a/cq_editor/widgets/debugger.py
+++ b/cq_editor/widgets/debugger.py
@@ -3,6 +3,7 @@ from contextlib import ExitStack, contextmanager
 from enum import Enum, auto
 from types import SimpleNamespace, FrameType, ModuleType
 from typing import List
+from bdb import BdbQuit
 
 import cadquery as cq
 from PyQt5 import QtCore
@@ -120,6 +121,7 @@ class Debugger(QObject,ComponentMixin):
     sigDebugging = pyqtSignal(bool)
 
     _frames : List[FrameType]
+    _stop_debugging : bool
 
     def __init__(self,parent):
 
@@ -156,8 +158,9 @@ class Debugger(QObject,ComponentMixin):
                               shortcut='ctrl+F12',
                               triggered=lambda: self.debug_cmd(DbgState.CONT))
                       ]}
-            
+
         self._frames = []
+        self._stop_debugging = False
 
     def get_current_script(self):
 
@@ -191,7 +194,27 @@ class Debugger(QObject,ComponentMixin):
             if self.preferences['Reload imported modules']:
                 stack.enter_context(module_manager())
 
-            exec(code, locals_dict, globals_dict)     
+            exec(code, locals_dict, globals_dict)
+
+    @staticmethod
+    def _rand_color(alpha = 0., cfloat=False):
+        #helper function to generate a random color dict
+        #for CQ-editor's show_object function
+        lower = 10
+        upper = 100 #not too high to keep color brightness in check
+        if cfloat: #for two output types depending on need
+            return (
+                    (rrr(lower,upper)/255),
+                    (rrr(lower,upper)/255),
+                    (rrr(lower,upper)/255),
+                    alpha,
+                    )
+        return {"alpha": alpha,
+                "color": (
+                          rrr(lower,upper),
+                          rrr(lower,upper),
+                          rrr(lower,upper),
+                         )}
 
     def _inject_locals(self,module):
 
@@ -207,29 +230,10 @@ class Debugger(QObject,ComponentMixin):
         def _debug(obj,name=None):
 
             _show_object(obj,name,options=dict(color='red',alpha=0.2))
-            
-        def _rand_color(alpha = 0., cfloat=False):
-            #helper function to generate a random color dict
-            #for CQ-editor's show_object function
-            lower = 10
-            upper = 100 #not too high to keep color brightness in check
-            if cfloat: #for two output types depending on need
-                return (
-                        (rrr(lower,upper)/255),
-                        (rrr(lower,upper)/255),
-                        (rrr(lower,upper)/255),
-                        alpha,
-                        )
-            return {"alpha": alpha,
-                    "color": (
-                              rrr(lower,upper),
-                              rrr(lower,upper),
-                              rrr(lower,upper),
-                             )}
 
         module.__dict__['show_object'] = _show_object
         module.__dict__['debug'] = _debug
-        module.__dict__['rand_color'] = _rand_color
+        module.__dict__['rand_color'] = self._rand_color
         module.__dict__['log'] = lambda x: info(str(x))
         module.__dict__['cq'] = cq
 
@@ -270,7 +274,7 @@ class Debugger(QObject,ComponentMixin):
             exc_info = sys.exc_info()
             sys.last_traceback = exc_info[-1]
             self.sigTraceback.emit(exc_info, cq_script)
-    
+
     @property
     def breakpoints(self):
         return [ el[0] for el in self.get_breakpoints()]
@@ -278,9 +282,12 @@ class Debugger(QObject,ComponentMixin):
     @pyqtSlot(bool)
     def debug(self,value):
 
-        previous_trace = sys.gettrace()
+        # used to stop the debugging session early
+        self._stop_debugging = False
 
         if value:
+            self.previous_trace = previous_trace = sys.gettrace()
+
             self.sigDebugging.emit(True)
             self.state = DbgState.STEP
 
@@ -301,6 +308,8 @@ class Debugger(QObject,ComponentMixin):
             try:
                 sys.settrace(self.trace_callback)
                 exec(code,module.__dict__,module.__dict__)
+            except BdbQuit:
+                pass
             except Exception:
                 exc_info = sys.exc_info()
                 sys.last_traceback = exc_info[-1]
@@ -317,12 +326,12 @@ class Debugger(QObject,ComponentMixin):
 
                 self._cleanup_locals(module,injected_names)
                 self.sigLocals.emit(module.__dict__)
-                
-                self._frames = []
-        else:
-            sys.settrace(previous_trace)
-            self.inner_event_loop.exit(0)
 
+                self._frames = []
+                self.inner_event_loop.exit(0)
+        else:
+            self._stop_debugging = True
+            self.inner_event_loop.exit(0)
 
     def debug_cmd(self,state=DbgState.STEP):
 
@@ -350,10 +359,10 @@ class Debugger(QObject,ComponentMixin):
         if event in (DbgEevent.LINE,):
             if (self.state in (DbgState.STEP, DbgState.STEP_IN) and frame is self._frames[-1]) \
             or (lineno in self.breakpoints):
-                
+
                 if lineno in self.breakpoints:
                     self._frames.append(frame)
-                
+
                 self.sigLineChanged.emit(lineno)
                 self.sigFrameChanged.emit(frame)
                 self.sigLocalsChanged.emit(frame.f_locals)
@@ -372,6 +381,9 @@ class Debugger(QObject,ComponentMixin):
                 self.sigFrameChanged.emit(frame)
                 self.state = DbgState.STEP
                 self._frames.append(frame)
+
+        if self._stop_debugging:
+            raise BdbQuit #stop debugging if requested
 
 
 @contextmanager

--- a/cq_editor/widgets/debugger.py
+++ b/cq_editor/widgets/debugger.py
@@ -193,25 +193,6 @@ class Debugger(QObject,ComponentMixin):
 
             exec(code, locals_dict, globals_dict)     
 
-    def _rand_color(self, alpha = 0., cfloat=False):
-        #helper function to generate a random color dict
-        #for CQ-editor's show_object function
-        lower = 10
-        upper = 100 #not too high to keep color brightness in check
-        if cfloat: #for two output types depending on need
-            return (
-                    (rrr(lower,upper)/255),
-                    (rrr(lower,upper)/255),
-                    (rrr(lower,upper)/255),
-                    alpha,
-                    )
-        return {"alpha": alpha,
-                "color": (
-                          rrr(lower,upper),
-                          rrr(lower,upper),
-                          rrr(lower,upper),
-                         )}
-
     def _inject_locals(self,module):
 
         cq_objects = {}
@@ -226,10 +207,29 @@ class Debugger(QObject,ComponentMixin):
         def _debug(obj,name=None):
 
             _show_object(obj,name,options=dict(color='red',alpha=0.2))
+            
+        def _rand_color(alpha = 0., cfloat=False):
+            #helper function to generate a random color dict
+            #for CQ-editor's show_object function
+            lower = 10
+            upper = 100 #not too high to keep color brightness in check
+            if cfloat: #for two output types depending on need
+                return (
+                        (rrr(lower,upper)/255),
+                        (rrr(lower,upper)/255),
+                        (rrr(lower,upper)/255),
+                        alpha,
+                        )
+            return {"alpha": alpha,
+                    "color": (
+                              rrr(lower,upper),
+                              rrr(lower,upper),
+                              rrr(lower,upper),
+                             )}
 
         module.__dict__['show_object'] = _show_object
         module.__dict__['debug'] = _debug
-        module.__dict__['rand_color'] = self._rand_color
+        module.__dict__['rand_color'] = _rand_color
         module.__dict__['log'] = lambda x: info(str(x))
         module.__dict__['cq'] = cq
 

--- a/cq_editor/widgets/debugger.py
+++ b/cq_editor/widgets/debugger.py
@@ -13,6 +13,7 @@ from logbook import info
 from path import Path
 from pyqtgraph.parametertree import Parameter
 from spyder.utils.icon_manager import icon
+from random import randrange as rrr,seed
 
 from ..cq_utils import find_cq_objects, reload_cq
 from ..mixins import ComponentMixin
@@ -192,6 +193,25 @@ class Debugger(QObject,ComponentMixin):
 
             exec(code, locals_dict, globals_dict)     
 
+    def _rand_color(self, alpha = 0., cfloat=False):
+        #helper function to generate a random color dict
+        #for CQ-editor's show_object function
+        lower = 10
+        upper = 100 #not too high to keep color brightness in check
+        if cfloat: #for two output types depending on need
+            return (
+                    (rrr(lower,upper)/255),
+                    (rrr(lower,upper)/255),
+                    (rrr(lower,upper)/255),
+                    alpha,
+                    )
+        return {"alpha": alpha,
+                "color": (
+                          rrr(lower,upper),
+                          rrr(lower,upper),
+                          rrr(lower,upper),
+                         )}
+
     def _inject_locals(self,module):
 
         cq_objects = {}
@@ -209,6 +229,7 @@ class Debugger(QObject,ComponentMixin):
 
         module.__dict__['show_object'] = _show_object
         module.__dict__['debug'] = _debug
+        module.__dict__['rand_color'] = self._rand_color
         module.__dict__['log'] = lambda x: info(str(x))
         module.__dict__['cq'] = cq
 
@@ -221,6 +242,7 @@ class Debugger(QObject,ComponentMixin):
     @pyqtSlot(bool)
     def render(self):
 
+        seed(371353)
         if self.preferences['Reload CQ']:
             reload_cq()
 

--- a/cq_editor/widgets/debugger.py
+++ b/cq_editor/widgets/debugger.py
@@ -246,7 +246,7 @@ class Debugger(QObject,ComponentMixin):
     @pyqtSlot(bool)
     def render(self):
 
-        seed(371353)
+        seed(59798267586177)
         if self.preferences['Reload CQ']:
             reload_cq()
 

--- a/cq_editor/widgets/debugger.py
+++ b/cq_editor/widgets/debugger.py
@@ -13,7 +13,6 @@ from logbook import info
 from path import Path
 from pyqtgraph.parametertree import Parameter
 from spyder.utils.icon_manager import icon
-from random import randrange as rrr, seed
 
 from ..cq_utils import find_cq_objects, reload_cq
 from ..mixins import ComponentMixin
@@ -191,27 +190,8 @@ class Debugger(QObject,ComponentMixin):
             if self.preferences['Reload imported modules']:
                 stack.enter_context(module_manager())
 
-            exec(code, locals_dict, globals_dict)    
+            exec(code, locals_dict, globals_dict)     
 
-    def _rand_color(self, alpha = 0., cfloat=False):
-        #helper function to generate a random color dict
-        #for CQ-editor's show_object function
-        lower = 10
-        upper = 100 #not too high to keep color brightness in check
-        if cfloat: #for two output types depending on need
-            return (
-                    (rrr(lower,upper)/255),
-                    (rrr(lower,upper)/255),
-                    (rrr(lower,upper)/255),
-                    alpha,
-                    )
-        return {"alpha": alpha,
-                "color": (
-                          rrr(lower,upper),
-                          rrr(lower,upper),
-                          rrr(lower,upper),
-                         )}
-      
     def _inject_locals(self,module):
 
         cq_objects = {}
@@ -229,7 +209,6 @@ class Debugger(QObject,ComponentMixin):
 
         module.__dict__['show_object'] = _show_object
         module.__dict__['debug'] = _debug
-        module.__dict__['rand_color'] = self._rand_color
         module.__dict__['log'] = lambda x: info(str(x))
         module.__dict__['cq'] = cq
 
@@ -241,7 +220,7 @@ class Debugger(QObject,ComponentMixin):
 
     @pyqtSlot(bool)
     def render(self):
-        seed(371353) #reset the seed every time render is called (preserves colors run to run)
+
         if self.preferences['Reload CQ']:
             reload_cq()
 

--- a/cq_editor/widgets/debugger.py
+++ b/cq_editor/widgets/debugger.py
@@ -13,6 +13,7 @@ from logbook import info
 from path import Path
 from pyqtgraph.parametertree import Parameter
 from spyder.utils.icon_manager import icon
+from random import randrange as rrr, seed
 
 from ..cq_utils import find_cq_objects, reload_cq
 from ..mixins import ComponentMixin
@@ -190,8 +191,27 @@ class Debugger(QObject,ComponentMixin):
             if self.preferences['Reload imported modules']:
                 stack.enter_context(module_manager())
 
-            exec(code, locals_dict, globals_dict)     
+            exec(code, locals_dict, globals_dict)    
 
+    def _rand_color(self, alpha = 0., cfloat=False):
+        #helper function to generate a random color dict
+        #for CQ-editor's show_object function
+        lower = 10
+        upper = 100 #not too high to keep color brightness in check
+        if cfloat: #for two output types depending on need
+            return (
+                    (rrr(lower,upper)/255),
+                    (rrr(lower,upper)/255),
+                    (rrr(lower,upper)/255),
+                    alpha,
+                    )
+        return {"alpha": alpha,
+                "color": (
+                          rrr(lower,upper),
+                          rrr(lower,upper),
+                          rrr(lower,upper),
+                         )}
+      
     def _inject_locals(self,module):
 
         cq_objects = {}
@@ -209,6 +229,7 @@ class Debugger(QObject,ComponentMixin):
 
         module.__dict__['show_object'] = _show_object
         module.__dict__['debug'] = _debug
+        module.__dict__['rand_color'] = self._rand_color
         module.__dict__['log'] = lambda x: info(str(x))
         module.__dict__['cq'] = cq
 
@@ -220,7 +241,7 @@ class Debugger(QObject,ComponentMixin):
 
     @pyqtSlot(bool)
     def render(self):
-
+        seed(371353) #reset the seed every time render is called (preserves colors run to run)
         if self.preferences['Reload CQ']:
             reload_cq()
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -403,6 +403,7 @@ def test_debug(main,mocker):
     patch_debugger(debugger,ev)
 
     debug.triggered.emit(True)
+    qtbot.wait(100)
     assert(variables.model().rowCount() == 2)
     assert(number_visible_items(viewer) == 4)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -403,7 +403,7 @@ def test_debug(main,mocker):
     patch_debugger(debugger,ev)
 
     debug.triggered.emit(True)
-    assert(variables.model().rowCount() == 1)
+    assert(variables.model().rowCount() == 2)
     assert(number_visible_items(viewer) == 4)
 
     #test exit debug

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -403,7 +403,7 @@ def test_debug(main,mocker):
     patch_debugger(debugger,ev)
 
     debug.triggered.emit(True)
-    assert(variables.model().rowCount() == 2)
+    assert(variables.model().rowCount() == 1)
     assert(number_visible_items(viewer) == 4)
 
     #test exit debug

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1520,3 +1520,28 @@ def test_show_all(main):
     debugger._actions['Run'][0].triggered.emit()
 
     assert(object_tree.CQ.childCount() == 4)
+
+code_randcolor = \
+"""import cadquery as cq
+b = cq.Workplane().box(8, 3, 4)
+for i in range(10):
+    show_object(b.translate((0,5*i,0)), options=rand_color(alpha=0))
+"""
+
+def test_randcolor(main):
+    
+    qtbot, win = main
+
+    obj_tree_comp = win.components['object_tree']
+    editor = win.components['editor']
+    debugger = win.components['debugger']
+    console = win.components['console']
+
+    # check that object was removed
+    obj_tree_comp._toolbar_actions[0].triggered.emit()
+    assert(obj_tree_comp.CQ.childCount() == 0)
+
+    # check that object was rendered usin explicit show_object call
+    editor.set_text(code_randcolor)
+    debugger._actions['Run'][0].triggered.emit()
+    assert(obj_tree_comp.CQ.childCount() == 10)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1526,6 +1526,7 @@ code_randcolor = \
 b = cq.Workplane().box(8, 3, 4)
 for i in range(10):
     show_object(b.translate((0,5*i,0)), options=rand_color(alpha=0))
+    show_object(b.translate((0,5*i,0)), options=rand_color(0, True))
 """
 
 def test_randcolor(main):
@@ -1544,4 +1545,4 @@ def test_randcolor(main):
     # check that object was rendered usin explicit show_object call
     editor.set_text(code_randcolor)
     debugger._actions['Run'][0].triggered.emit()
-    assert(obj_tree_comp.CQ.childCount() == 10)
+    assert(obj_tree_comp.CQ.childCount() == 2*10)


### PR DESCRIPTION
This PR adds a new function called `rand_color` to CQ-editor. This function gives a new random color each time it is called e.g. for a new object in `show_object`. Because of the way I have configured it (using random.seed) the colors are PRESERVED run-to-run. This function is nice when you need to highlight specific features and assign them a new color automatically, or as in the example below, when displaying objects in a loop.

```py
f1 = cq.Workplane('XY').box(8, 3, 4)
ytr = 0
for i in range(0,10):
    show_object(f1.translate((0,ytr,0)),options=rand_color(alpha=0))
    ytr += 5
```
![image](https://user-images.githubusercontent.com/16868537/199789386-7ecea794-9394-475d-8e1b-c3c8540cfff9.png)

I also registered this function for use in the CQ-editor console. The color "palette" can also be changed by prepending the above code with this:
```py
from random import seed
seed(123456)
f1 = cq.Workplane('XY').box(8, 3, 4)
ytr = 0
for i in range(0,10):
    show_object(f1.translate((0,ytr,0)),options=rand_color(alpha=0))
    ytr += 5
```
![image](https://user-images.githubusercontent.com/16868537/199790998-92b51537-332c-4bc0-ad49-de41e9599bc3.png)

The optional parameter `cfloat` outputs a different data format for use with changing the color of assembly objects.
```py
_rand_color(alpha = 0., cfloat=False)
```