### PR TITLE
Fix constructor missing library issue when env is not activated

### DIFF
--- a/conda/run.bat
+++ b/conda/run.bat
@@ -1,2 +1,2 @@
 @echo off
-start /B Scripts/CQ-editor.exe
+start /B Scripts\conda.exe run -n base python Scripts\cq-editor-script.py


### PR DESCRIPTION
* Call conda.exe run in win constructor run.bat script