### PR TITLE
Win32 strip console sequences in log

### DIFF
--- a/cq_editor/main_window.py
+++ b/cq_editor/main_window.py
@@ -1,5 +1,4 @@
 import sys
-import ctypes
 
 from PyQt5.QtWidgets import (QLabel, QMainWindow, QToolBar, QDockWidget, QAction)
 from logbook import Logger
@@ -32,10 +31,6 @@ class MainWindow(QMainWindow,MainMixin):
         MainMixin.__init__(self)
 
         self.setWindowIcon(icon('app'))
-        if sys.platform == "win32":
-            # Make the correct task bar icon show up.
-            myappid = 'cq-editor' # arbitrary string
-            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(myappid)
 
         self.viewer = OCCViewer(self)
         self.setCentralWidget(self.viewer.canvas)

--- a/cq_editor/main_window.py
+++ b/cq_editor/main_window.py
@@ -1,4 +1,5 @@
 import sys
+import ctypes
 
 from PyQt5.QtWidgets import (QLabel, QMainWindow, QToolBar, QDockWidget, QAction)
 from logbook import Logger
@@ -31,6 +32,10 @@ class MainWindow(QMainWindow,MainMixin):
         MainMixin.__init__(self)
 
         self.setWindowIcon(icon('app'))
+        if sys.platform == "win32":
+            # Make the correct task bar icon show up.
+            myappid = 'cq-editor' # arbitrary string
+            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(myappid)
 
         self.viewer = OCCViewer(self)
         self.setCentralWidget(self.viewer.canvas)

--- a/cq_editor/widgets/log.py
+++ b/cq_editor/widgets/log.py
@@ -1,9 +1,20 @@
 import logbook as logging
+import sys
+import re
 
 from PyQt5.QtWidgets import QPlainTextEdit
 from PyQt5 import QtCore
 
 from ..mixins import ComponentMixin
+
+def strip_escape_sequences(input_string):
+    # Regular expression pattern to match ANSI escape codes
+    escape_pattern = re.compile(r'\x1B\[[0-?]*[ -/]*[@-~]')
+
+    # Use re.sub to replace escape codes with an empty string
+    clean_string = re.sub(escape_pattern, '', input_string)
+
+    return clean_string
 
 class QtLogHandler(logging.Handler,logging.StringFormatterHandlerMixin):
     
@@ -17,6 +28,10 @@ class QtLogHandler(logging.Handler,logging.StringFormatterHandlerMixin):
     def emit(self, record):
         
         msg = self.format(record)
+
+        if sys.platform == "win32":
+            msg = strip_escape_sequences(msg)
+
         QtCore.QMetaObject\
             .invokeMethod(self.log_widget,
                           'appendPlainText',

--- a/cq_editor/widgets/log.py
+++ b/cq_editor/widgets/log.py
@@ -29,8 +29,7 @@ class QtLogHandler(logging.Handler,logging.StringFormatterHandlerMixin):
         
         msg = self.format(record)
 
-        if sys.platform == "win32":
-            msg = strip_escape_sequences(msg)
+        msg = strip_escape_sequences(msg)
 
         QtCore.QMetaObject\
             .invokeMethod(self.log_widget,


### PR DESCRIPTION
The console view has colored output. The escape sequences that make this happen are also included in the log view, which makes it hard to read. This patch removes all escape sequences from logged string.

I think this is an issue only on Windows, hence the platform guard. If this happens on other platforms, this guard should of course be deleted.