### PR TITLE
Python 3.12 fix: use importlib instead of imp

### DIFF
--- a/cq_editor/cq_utils.py
+++ b/cq_editor/cq_utils.py
@@ -2,7 +2,7 @@ import cadquery as cq
 from cadquery.occ_impl.assembly import toCAF
 
 from typing import List, Union
-from imp import reload
+from importlib import reload
 from types import SimpleNamespace
 
 from OCP.XCAFPrs import XCAFPrs_AISObject


### PR DESCRIPTION
The [imp](https://docs.python.org/3.11/library/imp.html) library has been deprecated since Python 3.4 and was finally removed in Python 3.12. For the isolated usecase within CQ-editor, replacing `imp` by its successor `importlib` seems to do the trick. importlib.reload was introduced in Python 3.4, so this would break support for older Python releases. Let me know in case support for older Python versions must be retained.

Additional info: I am not encountering any other issues running CQ-editor on Python 3.12, this appears to be the only fix required.