### PR TITLE
fix #338 Current document is not saved

### DIFF
--- a/cq_editor/widgets/editor.py
+++ b/cq_editor/widgets/editor.py
@@ -237,6 +237,7 @@ class Editor(CodeEditor,ComponentMixin):
         # neovim writes a file by removing it first so must re-add each time
         self._watch_paths()
         self.set_text_from_file(self._filename)
+        self.reset_modified()
         self.triggerRerender.emit(True)
 
     # Turn autoreload on/off.


### PR DESCRIPTION
This makes `_file_changed()` consistent with `load_from_file()`. With this change, `C-s C-o` goes straight to the file picker after doing something in the editor widget.

I noticed that `save` ends up calling `triggerRerender.emit(True)` both directly and through `_file_changed()`, but maybe that doesn't matter because I don't notice any slowness or flickering in the UI.