### PR TITLE
Explicitly add injected local variables for static analysis.

### DIFF
--- a/cq_editor/debugger_locals.py
+++ b/cq_editor/debugger_locals.py
@@ -1,0 +1,37 @@
+import inspect
+
+
+def show_object(obj, name=None, options={}):
+    return __call("show_object", obj, name, options)
+
+
+def debug(obj, name=None):
+    return __call("debug", obj, name)
+
+
+def rand_color():
+    return __call("rand_color")
+
+
+def log(message):
+    return __call("log", message)
+
+
+def __call(key, *args, **kwargs):
+    f = __find(key)
+    if f:
+        f(*args, **kwargs)
+
+
+def __find(key):
+    while True:
+        f = inspect.currentframe()
+        if f is None:
+            return None
+        f = f.f_back
+        if f is None:
+            return None
+        if f.__module__ == "__cq_main__":
+            break
+
+    return f.f_locals.get(key, None)


### PR DESCRIPTION
`debugger_locals` prevents VSCode or PyCharms from screaming whenever I use `log`, `debug`, etc...

![image](https://github.com/user-attachments/assets/c4aa338d-41aa-46d9-93c2-04dd3288ecd1)

Basic Usage:

```python
from cq_editor.debugger_locals import show_object

# ...

show_object(result)
```

Errors are silently ignored for in case of launching the project without cq-editor.
