### PR TITLE
"determine_encoding" considered harmful

### DIFF
--- a/cq_editor/widgets/editor.py
+++ b/cq_editor/widgets/editor.py
@@ -159,15 +159,6 @@ class Editor(CodeEditor,ComponentMixin):
         self.filename = fname
         self.reset_modified()
 
-    def determine_encoding(self, fname):
-        if os.path.exists(fname):
-            # this function returns the encoding spyder used to read the file
-            _, encoding = spyder.utils.encoding.read(fname)
-            # spyder returns a -guessed suffix in some cases
-            return encoding.replace('-guessed', '')
-        else:
-            return 'utf-8'
-
     def save(self):
 
         if self._filename != '':
@@ -176,10 +167,8 @@ class Editor(CodeEditor,ComponentMixin):
                 self._file_watcher.blockSignals(True)
                 self._file_watch_timer.stop()
 
-            encoding = self.determine_encoding(self._filename)
-            encoded = self.toPlainText().encode(encoding)
-            with open(self._filename, 'wb') as f:
-                f.write(encoded)
+            with open(self._filename, 'w') as f:
+                f.write(self.toPlainText())
 
             if self.preferences['Autoreload']:
                 self._file_watcher.blockSignals(False)
@@ -194,9 +183,8 @@ class Editor(CodeEditor,ComponentMixin):
 
         fname = get_save_filename(self.EXTENSIONS)
         if fname != '':
-            encoded = self.toPlainText().encode('utf-8')
-            with open(fname, 'wb') as f:
-                f.write(encoded)
+            with open(fname, 'w') as f:
+                f.write(self.toPlainText())
                 self.filename = fname
 
             self.reset_modified()


### PR DESCRIPTION
There is no reason to assume, in almost-2025, that a Python file is anything but UTF-8.

Thus, always write using the system encoding, which presumably is UTF-8 too.

The removed code causes data loss because if you open a file without UTF-8 codepoints >127 in it, Spyder says that its encoding is ASCII.

If you now add a seemingly-innocous character like an α (a perfectly valid Python variable name) or a comment with a 45° angle in it, you can no longer save the file. You get no error message; the text in the log viewer is easily overlooked, esp. as it doesn't auto-scroll down. Even if you see the error you cannot easily find the problem (where the heck is file position 4867, which character could possibly be 0xB0, and even after I determine that it's a degree sign, how do I *find* it)?