### PR TITLE
Possible fix for 'PosixPath' object does not support the context manager protocol

### DIFF
--- a/cq_editor/widgets/debugger.py
+++ b/cq_editor/widgets/debugger.py
@@ -198,7 +198,7 @@ class Debugger(QObject,ComponentMixin):
                 sys.path.insert(0,p)
                 stack.callback(sys.path.remove, p)
             if self.preferences['Change working dir to script dir'] and p.exists():
-                stack.enter_context(p)
+                stack.enter_context(open(p))
             if self.preferences['Reload imported modules']:
                 stack.enter_context(module_manager())
 


### PR DESCRIPTION
per user report on python 3.13

thanks also to @snoyer 

see also: https://bugs.python.org/issue39682

This is untested so far as I haven't been able to reproduce the bug myself yet.