### PR TITLE
Fix Segfault in Python 3.12

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - path
     - logbook
     - requests
-    - qtconsole=5.4.1
+    - qtconsole >=5.5.1,<5.6.0
 test:
   imports:
     - cq_editor

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -18,13 +18,13 @@ requirements:
     - setuptools
 
   run:
-    - python >=3.8
+    - python >=3.9
     - cadquery=master
     - ocp
     - logbook
     - pyqt=5.*
     - pyqtgraph
-    - spyder=5.*
+    - spyder >=5.5.6,<6
     - path
     - logbook
     - requests

--- a/cqgui_env.yml
+++ b/cqgui_env.yml
@@ -6,7 +6,7 @@ dependencies:
   - pyqt=5
   - pyqtgraph
   - python=3.10
-  - spyder=5
+  - spyder >=5.5.6,<6
   - path
   - logbook
   - requests

--- a/cqgui_env.yml
+++ b/cqgui_env.yml
@@ -11,4 +11,4 @@ dependencies:
   - logbook
   - requests
   - cadquery=master
-  - qtconsole=5.4.1
+  - qtconsole >=5.5.1,<5.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.4.dev0"
 dependencies = [
   "cadquery",
   "pyqtgraph",
-  "spyder==5",
+  "spyder>=5.5.6,<6",
   "path",
   "logbook",
   "requests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
   "path",
   "logbook",
   "requests",
-  "qtconsole==5.4.1"
+  "qtconsole>=5.5.1,<5.6.0"
 ]
 requires-python = ">=3.9,<3.13"
 authors = [


### PR DESCRIPTION
There is a segfault on Python 3.12 that seems to be caused by an out-of-date version of PyQt. There is also a deprecation with context manager since Python 3.11 that breaks Python 3.13.