### PR TITLE
Change to always forcing UTF-8 when saving

### DIFF
--- a/cq_editor/widgets/editor.py
+++ b/cq_editor/widgets/editor.py
@@ -159,15 +159,6 @@ class Editor(CodeEditor,ComponentMixin):
         self.filename = fname
         self.reset_modified()
 
-    def determine_encoding(self, fname):
-        if os.path.exists(fname):
-            # this function returns the encoding spyder used to read the file
-            _, encoding = spyder.utils.encoding.read(fname)
-            # spyder returns a -guessed suffix in some cases
-            return encoding.replace('-guessed', '')
-        else:
-            return 'utf-8'
-
     def save(self):
 
         if self._filename != '':
@@ -176,10 +167,8 @@ class Editor(CodeEditor,ComponentMixin):
                 self._file_watcher.blockSignals(True)
                 self._file_watch_timer.stop()
 
-            encoding = self.determine_encoding(self._filename)
-            encoded = self.toPlainText().encode(encoding)
-            with open(self._filename, 'wb') as f:
-                f.write(encoded)
+            with open(self._filename, 'w', encoding='utf-8') as f:
+                f.write(self.toPlainText())
 
             if self.preferences['Autoreload']:
                 self._file_watcher.blockSignals(False)
@@ -194,9 +183,8 @@ class Editor(CodeEditor,ComponentMixin):
 
         fname = get_save_filename(self.EXTENSIONS)
         if fname != '':
-            encoded = self.toPlainText().encode('utf-8')
-            with open(fname, 'wb') as f:
-                f.write(encoded)
+            with open(fname, 'w', encoding='utf-8') as f:
+                f.write(self.toPlainText())
                 self.filename = fname
 
             self.reset_modified()


### PR DESCRIPTION
Based on #463 with some additional changes, and will supersede that PR if this is merged. Between the Spyder version update and this, hopefully all of the encoding issues will be solved. Example encoding issue is [here](https://github.com/CadQuery/CQ-editor/issues/381).