### PR TITLE
Trying to Add a Few Smaller Features

### DIFF
--- a/cq_editor/icons.py
+++ b/cq_editor/icons.py
@@ -46,7 +46,8 @@ _icons_specs = {
                          {'options' : \
                           [{'scale_factor': 0.8},
                            {'scale_factor': 0.8,
-                            'offset': (.2,.2)}]})
+                            'offset': (.2,.2)}]}),
+    'toggle-comment' : (('fa.hashtag',),{}),
 }
 
 def icon(name):

--- a/cq_editor/main_window.py
+++ b/cq_editor/main_window.py
@@ -171,6 +171,12 @@ class MainWindow(QMainWindow,MainMixin):
 
         menu_edit.addAction( \
             QAction(icon('preferences'),
+                    'Toggle Comment',
+                    self,
+                    shortcut='ctrl+/',
+                    triggered=self.components['editor'].toggle_comment))
+        menu_edit.addAction( \
+            QAction(icon('preferences'),
                     'Preferences',
                     self,triggered=self.edit_preferences))
 

--- a/cq_editor/main_window.py
+++ b/cq_editor/main_window.py
@@ -61,6 +61,9 @@ class MainWindow(QMainWindow,MainMixin):
         self.restorePreferences()
         self.restoreWindow()
 
+        # Let the user know when the file has been modified
+        self.components['editor'].document().modificationChanged.connect(self.update_window_title)
+
         if filename:
             self.components['editor'].load_from_file(filename)
 
@@ -357,6 +360,14 @@ class MainWindow(QMainWindow,MainMixin):
         new_title = fname if fname else "*"
         self.setWindowTitle(f"{self.name}: {new_title}")
 
+    def update_window_title(self, modified):
+        """
+        Allows updating the window title to show that the document has been modified.
+        """
+        title = self.windowTitle().rstrip('*')
+        if modified:
+            title += '*'
+        self.setWindowTitle(title)
 
 class OutputRedirector(QObject):
     """

--- a/cq_editor/main_window.py
+++ b/cq_editor/main_window.py
@@ -170,7 +170,7 @@ class MainWindow(QMainWindow,MainMixin):
             menu_view.addAction(t.toggleViewAction())
 
         menu_edit.addAction( \
-            QAction(icon('preferences'),
+            QAction(icon('toggle-comment'),
                     'Toggle Comment',
                     self,
                     shortcut='ctrl+/',

--- a/cq_editor/widgets/editor.py
+++ b/cq_editor/widgets/editor.py
@@ -189,6 +189,13 @@ class Editor(CodeEditor,ComponentMixin):
 
             self.reset_modified()
 
+    def toggle_comment(self):
+        """
+        Allows us to mark the document as modified when the user toggles a comment.
+        """
+        super(Editor,self).toggle_comment()
+        self.document().setModified(True)
+
     def _update_filewatcher(self):
         if self._watched_file and (self._watched_file != self.filename or not self.preferences['Autoreload']):
             self._clear_watched_paths()

--- a/cq_editor/widgets/editor.py
+++ b/cq_editor/widgets/editor.py
@@ -171,8 +171,8 @@ class Editor(CodeEditor,ComponentMixin):
                 f.write(self.toPlainText())
 
             if self.preferences['Autoreload']:
-                self._file_watcher.blockSignals(False)
                 self.triggerRerender.emit(True)
+                # self._file_watcher.blockSignals(False)
 
             self.reset_modified()
 

--- a/cq_editor/widgets/editor.py
+++ b/cq_editor/widgets/editor.py
@@ -172,7 +172,7 @@ class Editor(CodeEditor,ComponentMixin):
 
             if self.preferences['Autoreload']:
                 self.triggerRerender.emit(True)
-                # self._file_watcher.blockSignals(False)
+                self._file_watcher.blockSignals(False)
 
             self.reset_modified()
 


### PR DESCRIPTION
- [x] Added a `Toggle Comment` item to the Edit menu and added the key combo Ctrl+/ for it, in addition to Spyder's `Ctrl+1`.
- [x] Redirected stdout to the Log Viewer so that all `print` statements can be viewed without running CQ-editor from the terminal.
- [x] Modifications to document are reflected via an asterisk in the window title.
- [x] Prevented the exception label from expanding the width of the main window