### PR TITLE
Fix for Preferences Drop Downs

### DIFF
--- a/cq_editor/preferences.py
+++ b/cq_editor/preferences.py
@@ -53,6 +53,28 @@ class PreferencesWidget(QDialog):
                                                     widget))
             
             self.stacked.addWidget(widget)
+
+            # PyQtGraph is not setting items in drop down lists properly, so we do it manually
+            for child in component.preferences.children():
+                # Fill the editor color scheme drop down list
+                if child.name() == 'Color scheme':
+                    child.setLimits(['Spyder','Monokai','Zenburn'])
+                # Fill the camera projection type
+                elif child.name() == 'Projection Type':
+                    child.setLimits(['Orthographic',
+                                     'Perspective',
+                                     'Stereo',
+                                     'MonoLeftEye',
+                                     'MonoRightEye'])
+                # Fill the stereo mode, or lack thereof
+                elif child.name() == 'Stereo Mode':
+                    child.setLimits(['QuadBuffer',
+                                     'Anaglyph',
+                                     'RowInterlaced',
+                                     'ColumnInterlaced',
+                                     'ChessBoard',
+                                     'SideBySide',
+                                     'OverUnder'])
             
     @pyqtSlot(QTreeWidgetItem,QTreeWidgetItem)          
     def handleSelection(self,item,*args):

--- a/cq_editor/widgets/editor.py
+++ b/cq_editor/widgets/editor.py
@@ -26,7 +26,7 @@ class Editor(CodeEditor,ComponentMixin):
     triggerRerender = pyqtSignal(bool)
     sigFilenameChanged = pyqtSignal(str)
 
-    preferences = Parameter.create(name='Preferences',children=[
+    preferences = Parameter.create(name='Preferences', children=[
         {'name': 'Font size', 'type': 'int', 'value': 12},
         {'name': 'Autoreload', 'type': 'bool', 'value': False},
         {'name': 'Autoreload delay', 'type': 'int', 'value': 50},

--- a/cq_editor/widgets/viewer.py
+++ b/cq_editor/widgets/viewer.py
@@ -31,12 +31,11 @@ class OCCViewer(QWidget,ComponentMixin):
 
     name = '3D Viewer'
 
-    preferences = Parameter.create(name='Pref',children=[
+    preferences = Parameter.create(name='Pref', children=[
         {'name': 'Fit automatically', 'type': 'bool', 'value': True},
         {'name': 'Use gradient', 'type': 'bool', 'value': False},
         {'name': 'Background color', 'type': 'color', 'value': (95,95,95)},
         {'name': 'Background color (aux)', 'type': 'color', 'value': (30,30,30)},
-        {'name': 'Default object color', 'type': 'color', 'value': "#FF0"},
         {'name': 'Deviation', 'type': 'float', 'value': 1e-5, 'dec': True, 'step': 1},
         {'name': 'Angular deviation', 'type': 'float', 'value': 0.1, 'dec': True, 'step': 1},
         {'name': 'Projection Type', 'type': 'list', 'value': 'Orthographic',
@@ -200,7 +199,6 @@ class OCCViewer(QWidget,ComponentMixin):
     @pyqtSlot(list)
     @pyqtSlot(list,bool)
     def display_many(self,ais_list,fit=None):
-
         context = self._get_context()
         for ais in ais_list:
             context.Display(ais,True)


### PR DESCRIPTION
As reported in #444 the drop downs in the Preferences dialog are not working. From what I've read, this is due to an update in PyQtGraph that breaks the way CQ-editor dynamically loads the drop downs. This work-around fixes that, with the drawback that it breaks from the original data-driven workflow, but only for the drop downs.