### PR TITLE
Dark Theme

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 shallow_clone: false
 
 image:
-    - Ubuntu2004
-    - Visual Studio 2015
+    - Ubuntu2204
+    - Visual Studio 2019
 
 environment:
     matrix:

--- a/cq_editor/main_window.py
+++ b/cq_editor/main_window.py
@@ -2,7 +2,14 @@ import sys
 
 from PyQt5.QtCore import QObject, pyqtSignal
 from PyQt5.QtGui import QPalette, QColor
-from PyQt5.QtWidgets import QLabel, QMainWindow, QToolBar, QDockWidget, QAction, QApplication
+from PyQt5.QtWidgets import (
+    QLabel,
+    QMainWindow,
+    QToolBar,
+    QDockWidget,
+    QAction,
+    QApplication,
+)
 from logbook import Logger
 import cadquery as cq
 
@@ -121,21 +128,20 @@ class MainWindow(QMainWindow, MainMixin):
 
         self.restoreComponentState()
 
-
     def preferencesChanged(self, param, changes):
         """
         Triggered when the preferences for this window are changed.
         """
 
         # Use the default light theme/palette
-        if self.preferences['Light/Dark Theme'] == 'Light':
+        if self.preferences["Light/Dark Theme"] == "Light":
             QApplication.instance().setStyleSheet("")
             QApplication.instance().setPalette(QApplication.style().standardPalette())
 
             # The console theme needs to be changed separately
-            self.components['console'].app_theme_changed('Light')
+            self.components["console"].app_theme_changed("Light")
         # Use the dark theme/palette
-        elif self.preferences['Light/Dark Theme'] == 'Dark':
+        elif self.preferences["Light/Dark Theme"] == "Dark":
             QApplication.instance().setStyle("Fusion")
 
             # Now use a palette to switch to dark colors:
@@ -159,11 +165,11 @@ class MainWindow(QMainWindow, MainMixin):
             QApplication.instance().setPalette(palette)
 
             # The console theme needs to be changed separately
-            self.components['console'].app_theme_changed('Dark')
+            self.components["console"].app_theme_changed("Dark")
 
         # We alter the color of the toolbar separately to avoid having separate dark theme icons
         p = self.toolbar.palette()
-        if self.preferences['Light/Dark Theme'] == 'Dark':
+        if self.preferences["Light/Dark Theme"] == "Dark":
             p.setColor(QPalette.Button, QColor(120, 120, 120))
             p.setColor(QPalette.Background, QColor(120, 120, 120))
         else:

--- a/cq_editor/preferences.py
+++ b/cq_editor/preferences.py
@@ -88,6 +88,9 @@ class PreferencesWidget(QDialog):
                             "OverUnder",
                         ]
                     )
+                # Fill the light/dark theme in the general settings
+                elif child.name() == "Light/Dark Theme":
+                    child.setLimits(["Light", "Dark"])
 
     @pyqtSlot(QTreeWidgetItem, QTreeWidgetItem)
     def handleSelection(self, item, *args):

--- a/cq_editor/widgets/console.py
+++ b/cq_editor/widgets/console.py
@@ -18,6 +18,26 @@ class ConsoleWidget(RichJupyterWidget, ComponentMixin):
         #            self.banner = customBanner
 
         self.font_size = 6
+        self.style_sheet = '''<style>
+                            QPlainTextEdit, QTextEdit {
+                                background-color: #3f3f3f;
+                                background-clip: padding;
+                                color: #dcdccc;
+                                selection-background-color: #484848;
+                            }
+                            .inverted {
+                                background-color: #dcdccc;
+                                color: #3f3f3f;
+                            }
+                            .error { color: red; }
+                            .in-prompt-number { font-weight: bold; }
+                            .out-prompt-number { font-weight: bold; }
+                            .in-prompt { color: navy; }
+                            .out-prompt { color: darkred; }
+                            </style>
+                            '''
+        self.syntax_style = 'zenburn'
+
         self.kernel_manager = kernel_manager = QtInProcessKernelManager()
         kernel_manager.start_kernel(show_banner=False)
         kernel_manager.kernel.gui = "qt"
@@ -67,6 +87,15 @@ class ConsoleWidget(RichJupyterWidget, ComponentMixin):
 
         return ""
 
+    def app_theme_changed(self, theme):
+        """
+        Allows this console to be changed to match the light or dark theme of the rest of the app.
+        """
+
+        if theme == 'Dark':
+            self.set_default_style('linux')
+        else:
+            self.set_default_style('lightbg')
 
 if __name__ == "__main__":
 

--- a/cq_editor/widgets/console.py
+++ b/cq_editor/widgets/console.py
@@ -18,7 +18,7 @@ class ConsoleWidget(RichJupyterWidget, ComponentMixin):
         #            self.banner = customBanner
 
         self.font_size = 6
-        self.style_sheet = '''<style>
+        self.style_sheet = """<style>
                             QPlainTextEdit, QTextEdit {
                                 background-color: #3f3f3f;
                                 background-clip: padding;
@@ -35,8 +35,8 @@ class ConsoleWidget(RichJupyterWidget, ComponentMixin):
                             .in-prompt { color: navy; }
                             .out-prompt { color: darkred; }
                             </style>
-                            '''
-        self.syntax_style = 'zenburn'
+                            """
+        self.syntax_style = "zenburn"
 
         self.kernel_manager = kernel_manager = QtInProcessKernelManager()
         kernel_manager.start_kernel(show_banner=False)
@@ -92,10 +92,11 @@ class ConsoleWidget(RichJupyterWidget, ComponentMixin):
         Allows this console to be changed to match the light or dark theme of the rest of the app.
         """
 
-        if theme == 'Dark':
-            self.set_default_style('linux')
+        if theme == "Dark":
+            self.set_default_style("linux")
         else:
-            self.set_default_style('lightbg')
+            self.set_default_style("lightbg")
+
 
 if __name__ == "__main__":
 

--- a/cqgui_env.yml
+++ b/cqgui_env.yml
@@ -10,6 +10,5 @@ dependencies:
   - path
   - logbook
   - requests
-  - cadquery=master
-  - ocp=7.8.1.1
+  - cadquery
   - qtconsole >=5.5.1,<5.6.0

--- a/cqgui_env.yml
+++ b/cqgui_env.yml
@@ -11,4 +11,5 @@ dependencies:
   - logbook
   - requests
   - cadquery=master
+  - ocp=7.8.1.1
   - qtconsole >=5.5.1,<5.6.0

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1664,3 +1664,34 @@ def test_print_redirect(main):
 
     qtbot.wait(100)
     assert "foo\nbar" in log.toPlainText()
+
+
+def test_light_dark_mode(main):
+    """
+    Tests that the app does switch between light and dark mode.
+    """
+    from PyQt5.QtGui import QPalette
+
+    qtbot, win = main
+
+    # Change to dark mode
+    win.preferences["Light/Dark Theme"] = "Dark"
+    win.preferencesChanged(None, None)
+
+    # Retireve the toolbar so that we can check its style
+    toolbar = win.toolbar
+
+    # Get the dark mode stylesheet for the toolbar
+    dark_pal = win.toolbar.palette()
+    dark_bg = dark_pal.color(QPalette.Background).rgb()
+
+    # Change to light mode
+    win.preferences["Light/Dark Theme"] = "Light"
+    win.preferencesChanged(None, None)
+
+    # Get the light mode stylesheet for the toolbar
+    light_pal = win.toolbar.palette()
+    light_bg = light_pal.color(QPalette.Background).rgb()
+
+    # Check that the dark mode stylesheet is different from the light mode stylesheet
+    assert dark_bg != light_bg


### PR DESCRIPTION
This PR is a mashup of my color theme changes along with changes from @jdegenstein @mbway and @axhan

I would have preferred to merge the original PRs so that credit can be traced back to each contributor, but this was a difficult feature to add without synthesizing all of the things that seemed to work best into one PR. The best I can do is tag those who contributed some of the pieces that ended up in this PR and give them credit and thanks.

To change the mode, change `Edit->Preferences->General->Light/Dark Theme`

I am debating whether to automatically change the editor theme and the background color of the 3D viewer when the user selects the theme. Currently, the user has to set those options separately in the Preferences dialog. If I change those automatically, it will wipe out the user's editor/viewer color preferences when they toggle Light/Dark mode. I'm not sure I want to do that. The editor also has two modes that are dark theme friendly, and chosing the one that is the default is a matter of preference (I like Monokai). Here is my current setup with the Monokai theme set for the editor and a slightly darker color set for the background of the 3D viewer. I've also been changing the object color with the `options` argument of the `show_object` method.

![Screenshot from 2025-02-17 17-42-06](https://github.com/user-attachments/assets/77a18231-0608-43bb-859f-9b561d40f8f2)
