### PR TITLE
Resolve real path to the executable

### DIFF
--- a/conda/run.sh
+++ b/conda/run.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec bin/cq-editor
+exec $(dirname $(realpath "$0"))/bin/cq-editor


### PR DESCRIPTION
The `run.sh` scripts assumes it is in the current working directory and fails to actually start the `bin/cq-editor` binary if it is not so, making the `$HOME/cq-editor/run.sh` suggested as the start command in https://cadquery.readthedocs.io/en/latest/installation.html#adding-a-nicer-gui-via-cq-editor fail.

Resolving the actual location of the script and using it to start the binary fixes the problem.