### PR TITLE
Add lowercase script alias "cq-editor"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
 
 [project.scripts]
 CQ-editor = "cq_editor.cqe_run:main"
+cq-editor = "cq_editor.cqe_run:main"
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
Add script "cq-editor" (lowercase) with the same entry point as "CQ-editor". This matches the behaviour of `setup.py`.