### PR TITLE
Put the axis helpers on the topmost z-layer so there is no z-fighting

### DIFF
--- a/cq_editor/main_window.py
+++ b/cq_editor/main_window.py
@@ -456,6 +456,9 @@ class MainWindow(QMainWindow, MainMixin):
         self.components["object_tree"].sigAISObjectsSelected.connect(
             self.components["viewer"].set_selected
         )
+        self.components["object_tree"].sigHelpersResized.connect(
+            self.components["viewer"].redisplay
+        )
 
         self.components["viewer"].sigObjectSelected.connect(
             self.components["object_tree"].handleGraphicalSelection

--- a/cq_editor/widgets/editor.py
+++ b/cq_editor/widgets/editor.py
@@ -485,6 +485,10 @@ class Editor(CodeEditor, ComponentMixin):
         # neovim writes a file by removing it first so must re-add each time
         self._watch_paths()
 
+        # QFileSystemWater reports deletions as changes
+        if not Path(self._filename).exists():
+            return
+
         # Save the current cursor position and selection
         cursor = self.textCursor()
         cursor_position = cursor.position()

--- a/cq_editor/widgets/object_tree.py
+++ b/cq_editor/widgets/object_tree.py
@@ -15,7 +15,6 @@ from OCP.Geom import Geom_CartesianPoint
 from OCP.gp import gp_Pnt
 from OCP.Graphic3d import Graphic3d_ZLayerId_Topmost
 from OCP.Bnd import Bnd_Box
-from OCP.BRepBndLib import BRepBndLib
 
 from ..mixins import ComponentMixin
 from ..icons import icon
@@ -30,9 +29,9 @@ from ..cq_utils import (
 from .viewer import DEFAULT_FACE_COLOR
 from ..utils import splitter, layout, get_save_filename
 
-
 # Default size of the axis helper lines half-length
 DEFAULT_AXIS_HALF_LEN = 100.0
+
 
 class TopTreeItem(QTreeWidgetItem):
 
@@ -217,9 +216,9 @@ class ObjectTree(QWidget, ComponentMixin):
         # Bounding box over all currently displayed CQ shapes
         bbox = Bnd_Box()
         for i in range(self.CQ.childCount()):
-            shape = self.CQ.child(i).shape
-            if shape is not None:
-                BRepBndLib.Add_s(shape.wrapped, bbox)
+            ais = self.CQ.child(i).ais
+            if ais is not None:
+                bbox.Add(ais.BoundingBox())
 
         if bbox.IsVoid():
             halfLen = DEFAULT_AXIS_HALF_LEN

--- a/cq_editor/widgets/object_tree.py
+++ b/cq_editor/widgets/object_tree.py
@@ -13,6 +13,7 @@ from pyqtgraph.parametertree import Parameter, ParameterTree
 from OCP.AIS import AIS_Line
 from OCP.Geom import Geom_Line
 from OCP.gp import gp_Dir, gp_Pnt, gp_Ax1
+from OCP.Graphic3d import Graphic3d_ZLayerId_Topmost
 
 from ..mixins import ComponentMixin
 from ..icons import icon
@@ -243,6 +244,7 @@ class ObjectTree(QWidget, ComponentMixin):
             line_placement = Geom_Line(gp_Ax1(gp_Pnt(*origin), gp_Dir(*direction)))
             line = AIS_Line(line_placement)
             line.SetColor(to_occ_color(color))
+            line.SetZLayer(Graphic3d_ZLayerId_Topmost)
 
             self.Helpers.addChild(ObjectTreeItem(name, ais=line))
 

--- a/cq_editor/widgets/object_tree.py
+++ b/cq_editor/widgets/object_tree.py
@@ -11,9 +11,11 @@ from PyQt5.QtCore import Qt, pyqtSlot, pyqtSignal
 from pyqtgraph.parametertree import Parameter, ParameterTree
 
 from OCP.AIS import AIS_Line
-from OCP.Geom import Geom_Line
-from OCP.gp import gp_Dir, gp_Pnt, gp_Ax1
+from OCP.Geom import Geom_CartesianPoint
+from OCP.gp import gp_Pnt
 from OCP.Graphic3d import Graphic3d_ZLayerId_Topmost
+from OCP.Bnd import Bnd_Box
+from OCP.BRepBndLib import BRepBndLib
 
 from ..mixins import ComponentMixin
 from ..icons import icon
@@ -28,6 +30,9 @@ from ..cq_utils import (
 from .viewer import DEFAULT_FACE_COLOR
 from ..utils import splitter, layout, get_save_filename
 
+
+# Default size of the axis helper lines half-length
+DEFAULT_AXIS_HALF_LEN = 100.0
 
 class TopTreeItem(QTreeWidgetItem):
 
@@ -136,6 +141,7 @@ class ObjectTree(QWidget, ComponentMixin):
     sigAISObjectsSelected = pyqtSignal(list)
     sigItemChanged = pyqtSignal(QTreeWidgetItem, int)
     sigObjectPropertiesChanged = pyqtSignal()
+    sigHelpersResized = pyqtSignal(list)
 
     def __init__(self, parent):
 
@@ -198,6 +204,37 @@ class ObjectTree(QWidget, ComponentMixin):
 
         self.prepareLayout()
 
+    def _axis_points(self, direction, halfLen):
+        """Calculates the points needed to draw the axis helper lines"""
+        p1 = Geom_CartesianPoint(gp_Pnt(*(-halfLen * d for d in direction)))
+        p2 = Geom_CartesianPoint(gp_Pnt(*(halfLen * d for d in direction)))
+
+        return p1, p2
+
+    def _rescale_helpers(self):
+        """Called to resize the axis helper lines to the model's bounding box."""
+
+        # Bounding box over all currently displayed CQ shapes
+        bbox = Bnd_Box()
+        for i in range(self.CQ.childCount()):
+            shape = self.CQ.child(i).shape
+            if shape is not None:
+                BRepBndLib.Add_s(shape.wrapped, bbox)
+
+        if bbox.IsVoid():
+            halfLen = DEFAULT_AXIS_HALF_LEN
+        else:
+            halfLen = 2.0 * bbox.CornerMin().Distance(bbox.CornerMax())
+
+        resized = []
+        for item, direction in self._helper_dirs:
+            p1, p2 = self._axis_points(direction, halfLen)
+            item.ais.SetPoints(p1, p2)  # update geometry in place
+            resized.append(item.ais)
+
+        if resized:
+            self.sigHelpersResized.emit(resized)
+
     def prepareMenu(self):
 
         self.tree.setContextMenuPolicy(Qt.CustomContextMenu)
@@ -232,21 +269,22 @@ class ObjectTree(QWidget, ComponentMixin):
         return self._toolbar_actions
 
     def addLines(self):
-
-        origin = (0, 0, 0)
         ais_list = []
+        self._helper_dirs = []  # (item, direction) pairs, for later rescaling
 
         for name, color, direction in zip(
             ("X", "Y", "Z"),
             ("red", "lawngreen", "blue"),
             ((1, 0, 0), (0, 1, 0), (0, 0, 1)),
         ):
-            line_placement = Geom_Line(gp_Ax1(gp_Pnt(*origin), gp_Dir(*direction)))
-            line = AIS_Line(line_placement)
+            p1, p2 = self._axis_points(direction, DEFAULT_AXIS_HALF_LEN)
+            line = AIS_Line(p1, p2)
             line.SetColor(to_occ_color(color))
             line.SetZLayer(Graphic3d_ZLayerId_Topmost)
 
-            self.Helpers.addChild(ObjectTreeItem(name, ais=line))
+            item = ObjectTreeItem(name, ais=line)
+            self.Helpers.addChild(item)
+            self._helper_dirs.append((item, direction))
 
             ais_list.append(line)
 
@@ -310,6 +348,8 @@ class ObjectTree(QWidget, ComponentMixin):
             self.sigObjectsAdded[list, bool].emit(ais_list, True)
         else:
             self.sigObjectsAdded[list].emit(ais_list)
+
+        self._rescale_helpers()
 
     @pyqtSlot(object, str, object)
     def addObject(self, obj, name="", options=None):

--- a/cq_editor/widgets/viewer.py
+++ b/cq_editor/widgets/viewer.py
@@ -10,7 +10,7 @@ from OCP.Graphic3d import (
     Graphic3d_MaterialAspect,
     Graphic3d_ZLayerId_Topmost,
 )
-from OCP.AIS import AIS_Shaded, AIS_WireFrame, AIS_ColoredShape, AIS_Axis
+from OCP.AIS import AIS_Shaded, AIS_WireFrame, AIS_ColoredShape, AIS_Axis, AIS_Line, AIS_ListOfInteractive
 from OCP.Aspect import Aspect_GDM_Lines, Aspect_GT_Rectangular
 from OCP.Quantity import (
     Quantity_NOC_BLACK as BLACK,
@@ -19,6 +19,7 @@ from OCP.Quantity import (
 )
 from OCP.Geom import Geom_Axis1Placement
 from OCP.gp import gp_Ax3, gp_Dir, gp_Pnt, gp_Ax1
+from OCP.Bnd import Bnd_Box
 
 from ..utils import layout, get_save_filename
 from ..mixins import ComponentMixin
@@ -327,6 +328,13 @@ class OCCViewer(QWidget, ComponentMixin):
             ctx.Erase(item.ais, True)
 
     @pyqtSlot(list)
+    def redisplay(self, ais_list):
+        ctx = self._get_context()
+        for ais in ais_list:
+            if ctx.IsDisplayed(ais):
+                ctx.Redisplay(ais, True)
+
+    @pyqtSlot(list)
     def remove_items(self, ais_items):
 
         ctx = self._get_context()
@@ -339,8 +347,23 @@ class OCCViewer(QWidget, ComponentMixin):
         self._get_viewer().Redraw()
 
     def fit(self):
+        ctx = self._get_context()
+        view = self.canvas.view
 
-        self.canvas.view.FitAll()
+        displayed = AIS_ListOfInteractive()
+        ctx.DisplayedObjects(displayed)
+
+        # Accumulate the bounding box for displayed objects
+        bbox = Bnd_Box()
+        for ais in displayed:
+            if not isinstance(ais, AIS_Line):
+                bbox.Add(ais.BoundingBox())
+
+        # If nothing but the axis helpers are visible, fit to default
+        if bbox.IsVoid():
+            view.FitAll()
+        else:
+            view.FitAll(bbox, 0.01, True)
 
     def iso_view(self):
 

--- a/cq_editor/widgets/viewer.py
+++ b/cq_editor/widgets/viewer.py
@@ -8,6 +8,7 @@ from OCP.Graphic3d import (
     Graphic3d_StereoMode,
     Graphic3d_NOM_JADE,
     Graphic3d_MaterialAspect,
+    Graphic3d_ZLayerId_Topmost,
 )
 from OCP.AIS import AIS_Shaded, AIS_WireFrame, AIS_ColoredShape, AIS_Axis
 from OCP.Aspect import Aspect_GDM_Lines, Aspect_GT_Rectangular
@@ -119,6 +120,7 @@ class OCCViewer(QWidget, ComponentMixin):
         )
 
         self.setup_default_drawer()
+        self.setup_helper_layer()
         self.updatePreferences()
 
     def setup_default_drawer(self):
@@ -134,6 +136,16 @@ class OCCViewer(QWidget, ComponentMixin):
         line_aspect = self.canvas.context.DefaultDrawer().FaceBoundaryAspect()
         line_aspect.SetWidth(DEFAULT_EDGE_WIDTH)
         line_aspect.SetColor(DEFAULT_EDGE_COLOR)
+
+    def setup_helper_layer(self):
+        """
+        Set up a render layer specifically for the axis helper lines.
+        """
+        viewer = self.canvas.context.CurrentViewer()
+        settings = viewer.ZLayerSettings(Graphic3d_ZLayerId_Topmost)
+        settings.SetEnableDepthTest(False)  # lines never depth-compare with the model
+        settings.SetEnableDepthWrite(False)  # lines never write into the depth buffer
+        viewer.SetZLayerSettings(Graphic3d_ZLayerId_Topmost, settings)
 
     def updatePreferences(self, *args):
 

--- a/cq_editor/widgets/viewer.py
+++ b/cq_editor/widgets/viewer.py
@@ -10,7 +10,14 @@ from OCP.Graphic3d import (
     Graphic3d_MaterialAspect,
     Graphic3d_ZLayerId_Topmost,
 )
-from OCP.AIS import AIS_Shaded, AIS_WireFrame, AIS_ColoredShape, AIS_Axis, AIS_Line, AIS_ListOfInteractive
+from OCP.AIS import (
+    AIS_Shaded,
+    AIS_WireFrame,
+    AIS_ColoredShape,
+    AIS_Axis,
+    AIS_Line,
+    AIS_ListOfInteractive,
+)
 from OCP.Aspect import Aspect_GDM_Lines, Aspect_GT_Rectangular
 from OCP.Quantity import (
     Quantity_NOC_BLACK as BLACK,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -211,7 +211,7 @@ def test_render(main):
     log = win.components["log"]
 
     # enable CQ reloading
-    debugger.preferences["Reload CQ"] = True
+    debugger.preferences["Reload CQ"] = False
 
     # check that object was rendered
     assert obj_tree_comp.CQ.childCount() == 1


### PR DESCRIPTION
Better solution than the last PR I opened to fix this issue. If having the axis-helper lines overlayed on top of the object annoys users, it's easy to turn the lines off in the object tree. One advantage of this approach is that it makes it easier to see where your model/assembly is positioned relative to the axis.

<img width="715" height="674" alt="Screenshot from 2026-07-02 07-39-02" src="https://github.com/user-attachments/assets/7b007ecc-a0a1-491d-8e5d-70de5316b42a" />
