### PR TITLE
Add a zoom-to-mouse-position option to the 3D viewer

### DIFF
--- a/cq_editor/widgets/occt_widget.py
+++ b/cq_editor/widgets/occt_widget.py
@@ -14,6 +14,9 @@ from OCP.AIS import AIS_InteractiveContext, AIS_DisplayMode
 from OCP.Quantity import Quantity_Color
 
 ZOOM_STEP = 0.9
+# Pixel delta fed to ZoomAtPoint so a wheel notch matches SetZoom(1 / ZOOM_STEP).
+# OCCT derives its coefficient as |delta| / 100 + 1.
+ZOOM_AT_POINT_STEP = round((1 / ZOOM_STEP - 1) * 100)
 
 
 class OCCTWidget(QWidget):
@@ -39,6 +42,9 @@ class OCCTWidget(QWidget):
 
         # Orbit method settings
         self._orbit_method = "Turntable"
+
+        # Zoom towards the cursor instead of the view center
+        self._zoom_to_cursor = False
 
         # OCCT secific things
         self.display_connection = Aspect_DisplayConnection()
@@ -87,12 +93,24 @@ class OCCTWidget(QWidget):
         else:
             raise ValueError(f"Unknown orbit method: {method}")
 
+    def set_zoom_to_cursor(self, enabled):
+
+        self._zoom_to_cursor = enabled
+
     def wheelEvent(self, event):
 
         delta = event.angleDelta().y()
-        factor = ZOOM_STEP if delta < 0 else 1 / ZOOM_STEP
 
-        self.view.SetZoom(factor)
+        if self._zoom_to_cursor:
+            pos = event.pos()
+            self.view.StartZoomAtPoint(pos.x(), pos.y())
+            if delta < 0:
+                self.view.ZoomAtPoint(ZOOM_AT_POINT_STEP, 0, 0, 0)
+            else:
+                self.view.ZoomAtPoint(0, 0, ZOOM_AT_POINT_STEP, 0)
+        else:
+            factor = ZOOM_STEP if delta < 0 else 1 / ZOOM_STEP
+            self.view.SetZoom(factor)
 
     def mousePressEvent(self, event):
 

--- a/cq_editor/widgets/viewer.py
+++ b/cq_editor/widgets/viewer.py
@@ -49,6 +49,7 @@ class OCCViewer(QWidget, ComponentMixin):
         name="Pref",
         children=[
             {"name": "Fit automatically", "type": "bool", "value": True},
+            {"name": "Zoom to mouse position", "type": "bool", "value": False},
             {"name": "Use gradient", "type": "bool", "value": False},
             {"name": "Background color", "type": "color", "value": (95, 95, 95)},
             {"name": "Background color (aux)", "type": "color", "value": (30, 30, 30)},
@@ -157,6 +158,8 @@ class OCCViewer(QWidget, ComponentMixin):
         if not orbit_method:
             orbit_method = "Trackball"
         self.canvas.set_orbit_method(orbit_method)
+
+        self.canvas.set_zoom_to_cursor(self.preferences["Zoom to mouse position"])
 
         self.canvas.update()
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2126,6 +2126,56 @@ def test_viewer_orbit_methods(main):
     assert True
 
 
+class _WheelEvent:
+    """Minimal stand-in for QWheelEvent; wheelEvent only reads these two."""
+
+    def __init__(self, pos, delta):
+        self._pos = pos
+        self._delta = delta
+
+    def pos(self):
+        return self._pos
+
+    def angleDelta(self):
+        return QPoint(0, self._delta)
+
+
+def test_viewer_zoom_to_mouse(main):
+    """
+    The 'Zoom to mouse position' preference switches wheel zooming between the
+    centered SetZoom behavior and zooming toward the cursor via ZoomAtPoint.
+    """
+
+    qtbot, win = main
+
+    viewer = win.components["viewer"]
+    debugger = win.components["debugger"]
+    canvas = viewer.canvas
+    view = canvas.view
+
+    # Render a shape so the view has something to zoom on
+    debugger._actions["Run"][0].triggered.emit()
+
+    # Preference off -> centered zoom, flag not set
+    viewer.preferences["Zoom to mouse position"] = False
+    assert canvas._zoom_to_cursor is False
+
+    scale0 = view.Scale()
+    canvas.wheelEvent(_WheelEvent(QPoint(10, 10), 120))
+    assert view.Scale() != pytest.approx(scale0)
+
+    # Preference on -> zoom toward the cursor, flag set through updatePreferences
+    viewer.preferences["Zoom to mouse position"] = True
+    assert canvas._zoom_to_cursor is True
+
+    scale1 = view.Scale()
+    canvas.wheelEvent(_WheelEvent(QPoint(10, 10), 120))
+    assert view.Scale() != pytest.approx(scale1)
+
+    # Both wheel directions are handled without error
+    canvas.wheelEvent(_WheelEvent(QPoint(30, 30), -120))
+
+
 # @pytest.mark.repeat(1)
 def test_editor_autoreload(editor):
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2157,6 +2157,56 @@ def test_viewer_orbit_methods(main):
     assert True
 
 
+class _WheelEvent:
+    """Minimal stand-in for QWheelEvent; wheelEvent only reads these two."""
+
+    def __init__(self, pos, delta):
+        self._pos = pos
+        self._delta = delta
+
+    def pos(self):
+        return self._pos
+
+    def angleDelta(self):
+        return QPoint(0, self._delta)
+
+
+def test_viewer_zoom_to_mouse(main):
+    """
+    The 'Zoom to mouse position' preference switches wheel zooming between the
+    centered SetZoom behavior and zooming toward the cursor via ZoomAtPoint.
+    """
+
+    qtbot, win = main
+
+    viewer = win.components["viewer"]
+    debugger = win.components["debugger"]
+    canvas = viewer.canvas
+    view = canvas.view
+
+    # Render a shape so the view has something to zoom on
+    debugger._actions["Run"][0].triggered.emit()
+
+    # Preference off -> centered zoom, flag not set
+    viewer.preferences["Zoom to mouse position"] = False
+    assert canvas._zoom_to_cursor is False
+
+    scale0 = view.Scale()
+    canvas.wheelEvent(_WheelEvent(QPoint(10, 10), 120))
+    assert view.Scale() != pytest.approx(scale0)
+
+    # Preference on -> zoom toward the cursor, flag set through updatePreferences
+    viewer.preferences["Zoom to mouse position"] = True
+    assert canvas._zoom_to_cursor is True
+
+    scale1 = view.Scale()
+    canvas.wheelEvent(_WheelEvent(QPoint(10, 10), 120))
+    assert view.Scale() != pytest.approx(scale1)
+
+    # Both wheel directions are handled without error
+    canvas.wheelEvent(_WheelEvent(QPoint(30, 30), -120))
+
+
 # @pytest.mark.repeat(1)
 def test_editor_autoreload(editor):
 


### PR DESCRIPTION
## Summary

Adds a **Zoom to mouse position** viewer preference. When enabled, the mouse wheel zooms toward the point under the cursor instead of the view center.

- New viewer preference **Zoom to mouse position** (default: off), so the existing entered-zoom behavior is unchanged unless the user opts in.
- When enabled, `wheelEvent` zooms via the view's `StartZoomAtPoint` / `ZoomAtPoint`; when disabled it keeps the original `SetZoom`.
- The per-notch zoom factor is matched to the existing `ZOOM_STEP`, so a wheel notch moves the same amount in both modes.

## Changes

- `cq_editor/widgets/occt_widget.py` — `ZOOM_AT_POINT_STEP` constant, `_zoom_to_cursor` flag, `set_zoom_to_cursor()`, and the `wheelEvent` branch.
- `cq_editor/widgets/viewer.py` — the preference and its wiring in `updatePreferences`.
- `tests/test_app.py` — `test_viewer_zoom_to_mouse` covering both wheel paths and the preference wiring.

## Testing

`pytest tests/test_app.py` — the new test and the existing viewer tests pass.

Claude AI assisted with the implementation under my direction; design, testing, and review are mine.