### PR TITLE
Fix PRINT_REDIRECTOR calling into a destroyed LogViewer

### DIFF
--- a/cq_editor/main_window.py
+++ b/cq_editor/main_window.py
@@ -291,9 +291,11 @@ class MainWindow(QMainWindow, MainMixin):
         for d in self.docks.values():
             d.show()
 
-        PRINT_REDIRECTOR.sigStdoutWrite.connect(
-            lambda text: self.components["log"].append(text)
-        )
+        # Connect the bound method rather than a lambda: PRINT_REDIRECTOR is a
+        # module-level singleton, and PyQt drops a connection to a QObject's
+        # bound method when that QObject is destroyed. A lambda would outlive
+        # the LogViewer and call into a deleted C++ object.
+        PRINT_REDIRECTOR.sigStdoutWrite.connect(self.components["log"].append)
 
     def prepare_menubar(self):
 

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -1,0 +1,37 @@
+import sys
+
+from PyQt5.QtWidgets import QMessageBox
+from PyQt5 import sip
+
+from cq_editor.__main__ import MainWindow
+from cq_editor.main_window import PRINT_REDIRECTOR
+
+
+def test_print_redirector_released_with_window(qtbot, mocker):
+    """
+    PRINT_REDIRECTOR is a module-level singleton that outlives any MainWindow.
+    Once a window's LogViewer is destroyed, a write must be dropped rather than
+    delivered to the now-deleted C++ object (which raises "wrapped C/C++ object
+    of type LogViewer has been deleted").
+    """
+
+    mocker.patch.object(QMessageBox, "question", return_value=QMessageBox.Yes)
+    mocker.patch.object(QMessageBox, "warning", return_value=QMessageBox.Discard)
+
+    win = MainWindow()
+    qtbot.addWidget(win)
+
+    # destroy this window's LogViewer, as tearing the window down would
+    sip.delete(win.components["log"])
+
+    # PyQt routes an exception raised inside a slot to sys.excepthook rather
+    # than propagating it, so capture it there while emitting
+    errors = []
+    original_hook = sys.excepthook
+    sys.excepthook = lambda exc_type, *rest: errors.append(exc_type)
+    try:
+        PRINT_REDIRECTOR.sigStdoutWrite.emit("stray output after close")
+    finally:
+        sys.excepthook = original_hook
+
+    assert errors == []


### PR DESCRIPTION
## Summary

`PRINT_REDIRECTOR` (a module-level singleton in `main_window.py`) connected a **lambda** to `sigStdoutWrite` for each `MainWindow`. The lambda was never disconnected, closed over `self`, and resolved `self.components["log"]` late through the dict `MainMixin` holds as a **class attribute** — so it reached whichever `LogViewer` registered last. Once a `LogViewer` was destroyed, the next `print()` called into a deleted C++ object and raised `RuntimeError: wrapped C/C++ object of type LogViewer has been deleted`.

Connecting the **bound method** `self.components["log"].append` instead lets PyQt drop the connection automatically when the `LogViewer` is destroyed.

## Testing

Adds `test_print_redirector_released_with_window`: destroys a window's `LogViewer`, emits on the singleton, and asserts no exception reaches `sys.excepthook`. It fails on the old lambda and passes with the fix.

`pytest tests/` — full suite passes.

The latent bug exists on master today; it just isn't exercised until multiple `MainWindow`s are created and torn down (as the display-modes tests do).

Claude AI found and fixed the issue.