### PR TITLE
Widen dock separators to make them easier to grab (#277)

### DIFF
--- a/cq_editor/main_window.py
+++ b/cq_editor/main_window.py
@@ -100,6 +100,11 @@ class MainWindow(QMainWindow, MainMixin):
         self.viewer = OCCViewer(self)
         self.setCentralWidget(self.viewer.canvas)
 
+        # Widen the dock separators so they are easy to grab. The default handle
+        # is only a couple of pixels wide, which is very hard to hit on macOS /
+        # high-DPI displays (#277).
+        self.setStyleSheet("QMainWindow::separator { width: 6px; height: 6px; }")
+
         self.prepare_panes()
         self.registerComponent("viewer", self.viewer)
         self.prepare_toolbar()

--- a/cq_editor/main_window.py
+++ b/cq_editor/main_window.py
@@ -12,6 +12,8 @@ from PyQt5.QtWidgets import (
     QAction,
     QApplication,
     QMenu,
+    QProxyStyle,
+    QStyle,
 )
 from logbook import Logger
 import cadquery as cq
@@ -63,6 +65,23 @@ class _PrintRedirectorSingleton(QObject):
 PRINT_REDIRECTOR = _PrintRedirectorSingleton()
 
 
+class DockSeparatorStyle(QProxyStyle):
+    """Widens the dock separators so that they are easier to grab (#277).
+
+    A style proxy is used instead of a stylesheet because setting a stylesheet
+    on the main window moves its whole widget subtree to QStyleSheetStyle,
+    which discards palette based theming (e.g. editor syntax highlighting).
+    """
+
+    def pixelMetric(self, metric, option=None, widget=None):
+
+        extent = super().pixelMetric(metric, option, widget)
+        if metric == QStyle.PM_DockWidgetSeparatorExtent:
+            return max(extent, 6)
+
+        return extent
+
+
 class MainWindow(QMainWindow, MainMixin):
 
     name = "CQ-Editor"
@@ -100,8 +119,10 @@ class MainWindow(QMainWindow, MainMixin):
         self.viewer = OCCViewer(self)
         self.setCentralWidget(self.viewer.canvas)
 
-        # Make sure the dock separators are wide enough to grab on high-DPI displays
-        self.setStyleSheet("QMainWindow::separator { width: 6px; height: 6px; }")
+        # Make sure the dock separators are wide enough to grab on high-DPI displays.
+        # setStyle does not take ownership, so keep a reference on self.
+        self._separator_style = DockSeparatorStyle()
+        self.setStyle(self._separator_style)
 
         self.prepare_panes()
         self.registerComponent("viewer", self.viewer)

--- a/cq_editor/main_window.py
+++ b/cq_editor/main_window.py
@@ -100,9 +100,7 @@ class MainWindow(QMainWindow, MainMixin):
         self.viewer = OCCViewer(self)
         self.setCentralWidget(self.viewer.canvas)
 
-        # Widen the dock separators so they are easy to grab. The default handle
-        # is only a couple of pixels wide, which is very hard to hit on macOS /
-        # high-DPI displays (#277).
+        # Make sure the dock separators are wide enough to grab on high-DPI displays
         self.setStyleSheet("QMainWindow::separator { width: 6px; height: 6px; }")
 
         self.prepare_panes()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,10 +12,11 @@ import pytestqt
 import cadquery as cq
 
 from PyQt5.QtCore import Qt, QSettings, QPoint, QEvent, QSize
-from PyQt5.QtWidgets import QFileDialog, QMessageBox
+from PyQt5.QtWidgets import QApplication, QFileDialog, QMessageBox, QStyle, QStyleFactory
 from PyQt5.QtGui import QMouseEvent
 
 from cq_editor.__main__ import MainWindow
+from cq_editor.main_window import DockSeparatorStyle
 from cq_editor.widgets.editor import Editor
 from cq_editor.cq_utils import export, get_occ_color
 
@@ -1706,6 +1707,31 @@ def test_launch_syntax_error(tmp_path):
 
     win.show()
     assert win.isVisible()
+
+
+def test_dock_separator_width(qtbot):
+
+    win = MainWindow()
+    qtbot.addWidget(win)
+
+    # separators are widened through a style proxy, not a stylesheet: a
+    # stylesheet on the main window would break palette based theming (#595)
+    assert win.styleSheet() == ""
+    assert win.style().pixelMetric(QStyle.PM_DockWidgetSeparatorExtent, None, win) >= 6
+
+    # child widgets keep the application style
+    editor = win.components["editor"]
+    assert editor.style().objectName() == QApplication.instance().style().objectName()
+
+
+def test_dock_separator_style_widens_small_extents(qtbot):
+
+    base = QStyleFactory.create("Windows")
+    assert base.pixelMetric(QStyle.PM_DockWidgetSeparatorExtent) < 6
+
+    style = DockSeparatorStyle(base)
+
+    assert style.pixelMetric(QStyle.PM_DockWidgetSeparatorExtent) == 6
 
 
 code_import_module_makebox = """

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,7 +12,13 @@ import pytestqt
 import cadquery as cq
 
 from PyQt5.QtCore import Qt, QSettings, QPoint, QEvent, QSize
-from PyQt5.QtWidgets import QApplication, QFileDialog, QMessageBox, QStyle, QStyleFactory
+from PyQt5.QtWidgets import (
+    QApplication,
+    QFileDialog,
+    QMessageBox,
+    QStyle,
+    QStyleFactory,
+)
 from PyQt5.QtGui import QMouseEvent
 
 from cq_editor.__main__ import MainWindow
@@ -1709,10 +1715,9 @@ def test_launch_syntax_error(tmp_path):
     assert win.isVisible()
 
 
-def test_dock_separator_width(qtbot):
+def test_dock_separator_width(main_clean):
 
-    win = MainWindow()
-    qtbot.addWidget(win)
+    qtbot, win = main_clean
 
     # separators are widened through a style proxy, not a stylesheet: a
     # stylesheet on the main window would break palette based theming (#595)


### PR DESCRIPTION
Fixes #277.

On macOS / high-DPI displays the dock separators are only a couple of pixels wide, so grabbing them to resize the panels is very hard. This adds a `QMainWindow::separator` stylesheet in `MainWindow.__init__` to widen them to 6px.

This is the fix @lorenzncode identified and @bendavis78 confirmed (5-10px comfortable) in the issue, matching the qss approach @adam-urbanczyk asked for there. The light/dark themes don't style `QMainWindow::separator`, so a theme switch won't clobber it. Verified the stylesheet applies cleanly on a PyQt5 QMainWindow with docks.
