### PR TITLE
Stop Return in the search box from deleting the matched text

### DIFF
--- a/cq_editor/widgets/code_editor.py
+++ b/cq_editor/widgets/code_editor.py
@@ -57,6 +57,21 @@ class SearchWidget(QtWidgets.QWidget):
         layout.addWidget(self.close_button)
         self.setLayout(layout)
 
+    def keyPressEvent(self, event):
+        """
+        Keeps Return from reaching the editor.
+
+        QLineEdit ignores Return after emitting returnPressed, and this widget
+        is a child of the editor, so the key would otherwise propagate up and
+        be inserted into the document. The current match is selected there,
+        which means the newline replaces the matched text.
+        """
+        if event.key() in (QtCore.Qt.Key_Return, QtCore.Qt.Key_Enter):
+            event.accept()
+            return
+
+        super(SearchWidget, self).keyPressEvent(event)
+
     def on_search_text_changed(self, text):
         """
         Called as the user types text into the search field.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -970,6 +970,35 @@ def test_search(editor):
     qtbot.keyClick(editor, Qt.Key_F3, modifier=Qt.AltModifier)
 
 
+def test_search_return_does_not_edit_document(editor):
+    """
+    Pressing Return in the search box should only advance to the next match,
+    never change the code.
+    """
+    qtbot, editor = editor
+
+    editor.set_text(base_editor_text)
+
+    # Open the search box and search for a term with more than one match
+    qtbot.keyClick(editor, Qt.Key_F, modifier=Qt.ControlModifier)
+    qtbot.keyClicks(editor.search_widget.search_input, "cq")
+    assert editor.search_widget.match_label.text() == "1 of 2"
+
+    # The current match is selected in the editor, so a Return that reaches it
+    # would replace the matched text with a newline
+    qtbot.keyClick(editor.search_widget.search_input, Qt.Key_Return)
+    assert editor.search_widget.match_label.text() == "2 of 2"
+    assert editor.get_text_with_eol() == base_editor_text
+
+    qtbot.keyClick(editor.search_widget.search_input, Qt.Key_Return)
+    assert editor.search_widget.match_label.text() == "1 of 2"
+    assert editor.get_text_with_eol() == base_editor_text
+
+    # Escape still closes the search box from within the search input
+    qtbot.keyClick(editor.search_widget.search_input, Qt.Key_Escape)
+    assert not editor.search_widget.isVisible()
+
+
 def test_line_number_area(editor):
     """
     Tests to make sure the line number area on the left of the editor is working correctly.


### PR DESCRIPTION
Pressing Return in the Ctrl+F search box deletes the match instead of moving to the next one.

Repro on master:

1. put `key=1` in the editor
2. Ctrl+F, type `key`
3. press Return

The document is now `\n=1`. Each further Return eats another match.

Cause: `QLineEdit` ignores Return after emitting `returnPressed`, and `SearchWidget` is a child of the editor, so the key propagates up to `CodeEditor.keyPressEvent` and `QPlainTextEdit` inserts a newline. `highlight_current_match()` puts the current match into the editor's text cursor via `setTextCursor()`, so that newline lands on a selection and replaces it.

Fix: accept Return/Enter in `SearchWidget.keyPressEvent` so it stops there. `find_next()` still runs from `returnPressed`, and Escape/F3 still reach the editor by propagation as before.

Test: `test_search_return_does_not_edit_document` sends real key events through the search input. It fails on master:

```
    import cadquery as cq
+   result =
-   result = cq.Workplane().box(10, 10, 10)
+   .Workplane().box(10, 10, 10)
```
